### PR TITLE
Added support for MongoDB and boilerplate user endpoint

### DIFF
--- a/ChessVariants.sln
+++ b/ChessVariants.sln
@@ -26,6 +26,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ChessVariantsAPI.Tests", "ChessVariantsAPI.Tests\ChessVariantsAPI.Tests.csproj", "{9DAFDB32-DFBF-47A5-ABF5-37231773D783}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DataAccess.MongoDB", "DataAccess.MongoDB\DataAccess.MongoDB.csproj", "{421DDAC7-6D0B-4BD1-8013-7C18D13FC669}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -48,6 +50,10 @@ Global
 		{9DAFDB32-DFBF-47A5-ABF5-37231773D783}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{9DAFDB32-DFBF-47A5-ABF5-37231773D783}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{9DAFDB32-DFBF-47A5-ABF5-37231773D783}.Release|Any CPU.Build.0 = Release|Any CPU
+		{421DDAC7-6D0B-4BD1-8013-7C18D13FC669}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{421DDAC7-6D0B-4BD1-8013-7C18D13FC669}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{421DDAC7-6D0B-4BD1-8013-7C18D13FC669}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{421DDAC7-6D0B-4BD1-8013-7C18D13FC669}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -57,6 +63,7 @@ Global
 		{F20F8B1B-D3C8-4795-866B-5D52E75E95F8} = {E05C37F4-5E64-4EE7-BF9A-E882C8925425}
 		{C0D6E8C8-5277-4C12-9E8D-F518289A95EF} = {E05C37F4-5E64-4EE7-BF9A-E882C8925425}
 		{9DAFDB32-DFBF-47A5-ABF5-37231773D783} = {12000BF7-323A-438B-956E-A27EEE3658D7}
+		{421DDAC7-6D0B-4BD1-8013-7C18D13FC669} = {E936EC73-C31F-42BF-BCBC-AE6C24963DF1}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {705A729B-BCC8-4D2F-90F5-767B8425E793}

--- a/ChessVariantsAPI/ChessVariantsAPI.csproj
+++ b/ChessVariantsAPI/ChessVariantsAPI.csproj
@@ -8,7 +8,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.Google" Version="6.0.14" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.2.3" />
   </ItemGroup>
 

--- a/ChessVariantsAPI/ChessVariantsAPI.csproj
+++ b/ChessVariantsAPI/ChessVariantsAPI.csproj
@@ -1,17 +1,20 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
+    <UserSecretsId>3e5fb6f3-bae7-4487-8f88-2c7bdeaf369c</UserSecretsId>
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.Google" Version="6.0.14" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.2.3" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\ChessVariantsLogic\ChessVariantsLogic.csproj" />
+    <ProjectReference Include="..\DataAccess.MongoDB\DataAccess.MongoDB.csproj" />
   </ItemGroup>
 
 </Project>

--- a/ChessVariantsAPI/Controllers/UsersController.cs
+++ b/ChessVariantsAPI/Controllers/UsersController.cs
@@ -1,0 +1,32 @@
+﻿using DataAccess.MongoDB;
+using DataAccess.MongoDB.Models;
+using Microsoft.AspNetCore.Mvc;
+
+namespace ChessVariantsAPI.Controllers;
+[Route("api/[controller]")]
+[ApiController]
+public class UsersController : ControllerBase
+{
+
+    private readonly DatabaseService _db;
+
+    public UsersController(DatabaseService databaseService)
+    {
+        _db = databaseService;
+    }
+
+    [HttpGet]
+    public async Task<ActionResult<IEnumerable<User>>> Get()
+    {
+        var users = await _db.Users.GetAsync();
+        return Ok(users);
+    }
+
+    [HttpPost]
+    public async Task<ActionResult<User>> Post(User user)
+    {
+        user = new User { Email = user.Email, FirstName = user.FirstName, LastName = user.LastName, UserName = user.UserName };
+        await _db.Users.CreateAsync(user);
+        return CreatedAtAction("Get", new {id = user.Id}, user);
+    }
+}

--- a/ChessVariantsAPI/Program.cs
+++ b/ChessVariantsAPI/Program.cs
@@ -1,4 +1,7 @@
 using ChessVariantsAPI;
+using DataAccess.MongoDB;
+using Microsoft.AspNetCore.Authentication.Google;
+using Microsoft.AspNetCore.Identity;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -10,6 +13,18 @@ builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
 builder.Services.AddSignalR();
 builder.Services.AddGameOrganzation();
+builder.Services.AddSingleton<DatabaseService>(new TestDatabaseService(builder.Configuration["MongoDatabase:ConnectionString"]));
+
+//builder.Services.AddAuthentication(options =>
+//{
+//    options.DefaultAuthenticateScheme = GoogleDefaults.AuthenticationScheme;
+//    options.DefaultChallengeScheme = GoogleDefaults.AuthenticationScheme;
+//})
+//.AddGoogle(googleOptions =>
+//{
+//    googleOptions.ClientId = builder.Configuration["Authentication:Google:ClientId"];
+//    googleOptions.ClientSecret = builder.Configuration["Authentication:Google:ClientSecret"];
+//});
 
 var app = builder.Build();
 
@@ -25,9 +40,12 @@ if (app.Environment.IsDevelopment())
             .AllowCredentials());
 }
 
+
+
 app.UseHttpsRedirection();
 
-app.UseAuthorization();
+//app.UseAuthorization();
+//app.UseAuthentication();
 
 app.MapControllers();
 app.MapHubs();

--- a/ChessVariantsAPI/Program.cs
+++ b/ChessVariantsAPI/Program.cs
@@ -1,7 +1,5 @@
 using ChessVariantsAPI;
 using DataAccess.MongoDB;
-using Microsoft.AspNetCore.Authentication.Google;
-using Microsoft.AspNetCore.Identity;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -14,17 +12,6 @@ builder.Services.AddSwaggerGen();
 builder.Services.AddSignalR();
 builder.Services.AddGameOrganzation();
 builder.Services.AddSingleton<DatabaseService>(new TestDatabaseService(builder.Configuration["MongoDatabase:ConnectionString"]));
-
-//builder.Services.AddAuthentication(options =>
-//{
-//    options.DefaultAuthenticateScheme = GoogleDefaults.AuthenticationScheme;
-//    options.DefaultChallengeScheme = GoogleDefaults.AuthenticationScheme;
-//})
-//.AddGoogle(googleOptions =>
-//{
-//    googleOptions.ClientId = builder.Configuration["Authentication:Google:ClientId"];
-//    googleOptions.ClientSecret = builder.Configuration["Authentication:Google:ClientSecret"];
-//});
 
 var app = builder.Build();
 
@@ -43,9 +30,6 @@ if (app.Environment.IsDevelopment())
 
 
 app.UseHttpsRedirection();
-
-//app.UseAuthorization();
-//app.UseAuthentication();
 
 app.MapControllers();
 app.MapHubs();

--- a/DataAccess.MongoDB/DataAccess.MongoDB.csproj
+++ b/DataAccess.MongoDB/DataAccess.MongoDB.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="MongoDB.Driver" Version="2.19.0" />
+  </ItemGroup>
+
+</Project>

--- a/DataAccess.MongoDB/Database/DatabaseService.cs
+++ b/DataAccess.MongoDB/Database/DatabaseService.cs
@@ -1,0 +1,21 @@
+﻿using MongoDB.Driver;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace DataAccess.MongoDB;
+public class DatabaseService
+{
+    private readonly IMongoClient _client;
+    private readonly IMongoDatabase _database;
+    public readonly UserRepository Users;
+
+    public DatabaseService(string connectionString, string databaseName)
+    {
+        _client = new MongoClient(connectionString);
+        _database = _client.GetDatabase(databaseName);
+        Users = new UserRepository(_database);
+    }
+}

--- a/DataAccess.MongoDB/Database/DatabaseService.cs
+++ b/DataAccess.MongoDB/Database/DatabaseService.cs
@@ -1,9 +1,4 @@
 ﻿using MongoDB.Driver;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace DataAccess.MongoDB;
 public class DatabaseService

--- a/DataAccess.MongoDB/Database/TestDatabaseService.cs
+++ b/DataAccess.MongoDB/Database/TestDatabaseService.cs
@@ -1,11 +1,5 @@
-﻿using MongoDB.Driver;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿namespace DataAccess.MongoDB;
 
-namespace DataAccess.MongoDB;
 public class TestDatabaseService : DatabaseService
 {
     public TestDatabaseService(string connectionString) : base(connectionString, "Test") {}

--- a/DataAccess.MongoDB/Database/TestDatabaseService.cs
+++ b/DataAccess.MongoDB/Database/TestDatabaseService.cs
@@ -1,0 +1,12 @@
+﻿using MongoDB.Driver;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace DataAccess.MongoDB;
+public class TestDatabaseService : DatabaseService
+{
+    public TestDatabaseService(string connectionString) : base(connectionString, "Test") {}
+}

--- a/DataAccess.MongoDB/Models/IModel.cs
+++ b/DataAccess.MongoDB/Models/IModel.cs
@@ -1,10 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿namespace DataAccess.MongoDB.Models;
 
-namespace DataAccess.MongoDB.Models;
 public interface IModel
 {
     public string Id { get; set; }

--- a/DataAccess.MongoDB/Models/IModel.cs
+++ b/DataAccess.MongoDB/Models/IModel.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace DataAccess.MongoDB.Models;
+public interface IModel
+{
+    public string Id { get; set; }
+}

--- a/DataAccess.MongoDB/Models/User.cs
+++ b/DataAccess.MongoDB/Models/User.cs
@@ -1,10 +1,5 @@
 ﻿using MongoDB.Bson;
 using MongoDB.Bson.Serialization.Attributes;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace DataAccess.MongoDB.Models;
 public class User : IModel

--- a/DataAccess.MongoDB/Models/User.cs
+++ b/DataAccess.MongoDB/Models/User.cs
@@ -1,0 +1,19 @@
+﻿using MongoDB.Bson;
+using MongoDB.Bson.Serialization.Attributes;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace DataAccess.MongoDB.Models;
+public class User : IModel
+{
+    [BsonId]
+    [BsonRepresentation(BsonType.ObjectId)]
+    public string Id { get; set; } = null!;
+    public string UserName { get; set; } = null!;
+    public string FirstName { get; set; } = null!;
+    public string LastName { get; set; } = null!;
+    public string Email { get; set; } = null!;
+}

--- a/DataAccess.MongoDB/Program.cs
+++ b/DataAccess.MongoDB/Program.cs
@@ -1,0 +1,10 @@
+﻿// See https://aka.ms/new-console-template for more information
+using MongoDB.Bson;
+using MongoDB.Bson.Serialization.Attributes;
+using MongoDB.Driver;
+
+// For manual testing
+var settings = MongoClientSettings.FromConnectionString("mongodb+srv://chessvariantsapi:<PASSWORD>@chess.yuskina.mongodb.net/?retryWrites=true&w=majority");
+settings.ServerApi = new ServerApi(ServerApiVersion.V1);
+var client = new MongoClient(settings);
+var database = client.GetDatabase("Test");

--- a/DataAccess.MongoDB/Program.cs
+++ b/DataAccess.MongoDB/Program.cs
@@ -1,6 +1,4 @@
 ﻿// See https://aka.ms/new-console-template for more information
-using MongoDB.Bson;
-using MongoDB.Bson.Serialization.Attributes;
 using MongoDB.Driver;
 
 // For manual testing

--- a/DataAccess.MongoDB/Repositories/GenericRepository.cs
+++ b/DataAccess.MongoDB/Repositories/GenericRepository.cs
@@ -1,0 +1,43 @@
+﻿using DataAccess.MongoDB.Models;
+using MongoDB.Driver;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace DataAccess.MongoDB;
+public class GenericRepository<T> where T : IModel
+{
+    readonly protected IMongoCollection<T> _collection;
+
+    public GenericRepository(IMongoCollection<T> collection)
+    {
+        _collection = collection;
+    }
+
+    public async Task<List<T>> GetAsync()
+    {
+        return await _collection.Find(_ => true).ToListAsync();
+    }
+
+    public async Task<T?> GetAsync(string id)
+    {
+        return await _collection.Find(x => x.Id == id).FirstOrDefaultAsync();
+    }
+
+    public async Task CreateAsync(T newT)
+    {
+        await _collection.InsertOneAsync(newT);
+    }
+
+    public async Task UpdateAsync(string id, T updatedT)
+    {
+        await _collection.ReplaceOneAsync(x => x.Id == id, updatedT);
+    }
+
+    public async Task RemoveAsync(string id)
+    {
+        await _collection.DeleteOneAsync(x => x.Id == id);
+    }
+}

--- a/DataAccess.MongoDB/Repositories/GenericRepository.cs
+++ b/DataAccess.MongoDB/Repositories/GenericRepository.cs
@@ -1,10 +1,5 @@
 ﻿using DataAccess.MongoDB.Models;
 using MongoDB.Driver;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace DataAccess.MongoDB;
 public class GenericRepository<T> where T : IModel

--- a/DataAccess.MongoDB/Repositories/UserRepository.cs
+++ b/DataAccess.MongoDB/Repositories/UserRepository.cs
@@ -1,10 +1,5 @@
 ﻿using DataAccess.MongoDB.Models;
 using MongoDB.Driver;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace DataAccess.MongoDB;
 public class UserRepository : GenericRepository<User>

--- a/DataAccess.MongoDB/Repositories/UserRepository.cs
+++ b/DataAccess.MongoDB/Repositories/UserRepository.cs
@@ -1,0 +1,16 @@
+﻿using DataAccess.MongoDB.Models;
+using MongoDB.Driver;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace DataAccess.MongoDB;
+public class UserRepository : GenericRepository<User>
+{
+    public const string CollectionName = "Users";
+
+    public UserRepository(IMongoDatabase database) : base(database.GetCollection<User>(CollectionName)) {}
+
+}


### PR DESCRIPTION
What's changed?

1. Added a new project `DataAccess.MongoDB` which handles connecting to the database and abstracts usage. It does this by using repositories, that define what actions can be taken on each model (i.e a `User`)
2. Added a project reference for `DataAccess.MongoDB` in `ChessVariantsAPI`. The API creates a singleton of the database connection which is then dependency injected into controllers, or wherever else.
3. Added a `UsersController` where you can create / get users using HTTP(S). This is just to verify that it works and is currently very premature.

To be able to connect to the database you need the connection string as the db is hosted on MongoDB Atlas. I've sent a setup guide in discord.

I haven't had time to document the code as I've been very busy, but I think it's pretty self-explanatory at this stage at least!