### PR TITLE
Implementation of duck chess

### DIFF
--- a/ChessVariantsLogic.Tests/ChessboardTests.cs
+++ b/ChessVariantsLogic.Tests/ChessboardTests.cs
@@ -1,3 +1,4 @@
+using ChessVariantsLogic.Rules.Moves;
 using System;
 using System.Collections.Generic;
 using Xunit;
@@ -359,13 +360,16 @@ public class ChessboardTests
     {
         var moveWorker = new MoveWorker(Chessboard.StandardChessboard(), Piece.AllStandardPieces());
 
+        Move move0 = new Move("e2e3", PieceClassifier.WHITE);
+        Move move1 = new Move("e7e6", PieceClassifier.BLACK);
+
         var moves = moveWorker.GetAllCaptureMoves(Player.White);
         Assert.Equal(18, moves.Count);
-        Assert.Equal(GameEvent.MoveSucceeded, moveWorker.Move("e2e3"));
+        Assert.Equal(GameEvent.MoveSucceeded, move0.Perform(moveWorker));
         var moves2 = moveWorker.GetAllCaptureMoves(Player.White);
         Assert.Equal(27, moves2.Count);
         
-        Assert.Equal(GameEvent.MoveSucceeded, moveWorker.Move("e7e6"));
+        Assert.Equal(GameEvent.MoveSucceeded, move1.Perform(moveWorker));
         Assert.Equal(2, moveWorker.Movelog.Count);
         
         moveWorker.Board = new Chessboard(8);

--- a/ChessVariantsLogic.Tests/RulesTests/ChessPredicateTests/AttackedTests.cs
+++ b/ChessVariantsLogic.Tests/RulesTests/ChessPredicateTests/AttackedTests.cs
@@ -31,11 +31,11 @@ public class AttackedTests : IDisposable {
         blackBishopOnE2 = new MoveWorker(Chessboard.StandardChessboard(), Piece.AllStandardPieces());
         blackBishopOnE2.Board.Insert(Constants.BlackBishopIdentifier, "e2");
 
-        boardBoard = new BoardTransition(board, new Move("a1a1"));
-        whiteKingAttackedTransition = new BoardTransition(whiteKingAttackedBoard, new Move("a1a1"));
-        blackBishopOnE2Transition = new BoardTransition(blackBishopOnE2, new Move("a1a1"));
+        boardBoard = new BoardTransition(board, new Move("a1a1", PieceClassifier.WHITE));
+        whiteKingAttackedTransition = new BoardTransition(whiteKingAttackedBoard, new Move("a1a1", PieceClassifier.WHITE));
+        blackBishopOnE2Transition = new BoardTransition(blackBishopOnE2, new Move("a1a1", PieceClassifier.WHITE));
 
-        blackToWhiteKingAttackedTransition = new BoardTransition(blackKingAttackedBoard, new Move("a1a1"));
+        blackToWhiteKingAttackedTransition = new BoardTransition(blackKingAttackedBoard, new Move("a1a1", PieceClassifier.WHITE));
 
     }
 

--- a/ChessVariantsLogic.Tests/RulesTests/ChessPredicateTests/FirstMoveTests.cs
+++ b/ChessVariantsLogic.Tests/RulesTests/ChessPredicateTests/FirstMoveTests.cs
@@ -7,25 +7,21 @@ using ChessVariantsLogic.Rules.Moves;
 
 namespace ChessVariantsLogic.Tests;
 
-public class LastMoveTests
+public class FirstMoveTests
 {
     MoveWorker board;
     BoardTransition boardTransition0;
     BoardTransition boardTransition1;
-    IPosition from;
-    IPosition to;
     string fromStr;
     string toStr0;
     string toStr1;
 
-    public LastMoveTests()
+    public FirstMoveTests()
     {
         board = new MoveWorker(Chessboard.StandardChessboard(), Piece.AllStandardPieces());
         fromStr = "e2";
         toStr0 = "e3";
         toStr1 = "e4";
-        from = new PositionAbsolute(fromStr);
-        to = new PositionAbsolute(toStr0);
         Move move0 = new Move(fromStr + toStr0, PieceClassifier.WHITE);
         Move move1 = new Move(toStr0 + toStr1, PieceClassifier.WHITE);
 
@@ -34,15 +30,15 @@ public class LastMoveTests
     }
 
     [Fact]
-    public void LastMoveWasE2E3_ShouldReturnTrue()
+    public void FirstMove_ShouldReturnTrue()
     {
-        IPredicate lastMoveWasE2E3 = new LastMove(from, to);
-        Assert.True(lastMoveWasE2E3.Evaluate(boardTransition1));
+        IPredicate firstMove = new FirstMove();
+        Assert.True(firstMove.Evaluate(boardTransition0));
     }
     [Fact]
-    public void LastMoveWasE2E3_ShouldReturnFalse()
+    public void FirstMove_ShouldReturnFalse()
     {
-        IPredicate lastMoveWasE2E3 = new LastMove(from, to);
-        Assert.False(lastMoveWasE2E3.Evaluate(boardTransition0));
+        IPredicate firstMove = new FirstMove();
+        Assert.False(firstMove.Evaluate(boardTransition1));
     }
 }

--- a/ChessVariantsLogic.Tests/RulesTests/ChessPredicateTests/ForEveryTests.cs
+++ b/ChessVariantsLogic.Tests/RulesTests/ChessPredicateTests/ForEveryTests.cs
@@ -63,9 +63,9 @@ public class ForEveryTests : IDisposable {
 
         whiteWinRule = new ForEvery(blackKingCheckedThisAndNextTurn, Player.Black);
 
-        scholarsMateBoardTransition = new BoardTransition(scholarsMateBoard, new Move("a1a1"));
-        notScholarsMateBoardTransition = new BoardTransition(notScholarsMateBoard, new Move("a1a1"));
-        boardTransition = new BoardTransition(board, new Move("a1a1"));
+        scholarsMateBoardTransition = new BoardTransition(scholarsMateBoard, new Move("a1a1", PieceClassifier.WHITE));
+        notScholarsMateBoardTransition = new BoardTransition(notScholarsMateBoard, new Move("a1a1", PieceClassifier.WHITE));
+        boardTransition = new BoardTransition(board, new Move("a1a1", PieceClassifier.WHITE));
 
     }
 

--- a/ChessVariantsLogic.Tests/RulesTests/ChessPredicateTests/HasMovedTests.cs
+++ b/ChessVariantsLogic.Tests/RulesTests/ChessPredicateTests/HasMovedTests.cs
@@ -22,7 +22,7 @@ public class HasMovedTests
         toStr = "e3";
         from = new PositionAbsolute(fromStr);
         to = new PositionAbsolute(toStr);
-        Move move = new Move(fromStr + toStr);
+        Move move = new Move(fromStr + toStr, PieceClassifier.WHITE);
 
         boardTransition = new BoardTransition(board, move);
     }

--- a/ChessVariantsLogic.Tests/RulesTests/ChessPredicateTests/LastMoveClassifierTests.cs
+++ b/ChessVariantsLogic.Tests/RulesTests/ChessPredicateTests/LastMoveClassifierTests.cs
@@ -1,0 +1,64 @@
+using Xunit;
+using System;
+using ChessVariantsLogic.Rules.Predicates;
+using ChessVariantsLogic.Rules.Predicates.ChessPredicates;
+using ChessVariantsLogic.Rules;
+using ChessVariantsLogic.Rules.Moves;
+
+namespace ChessVariantsLogic.Tests;
+
+public class LastMoveClassifierTests
+{
+    MoveWorker board;
+    BoardTransition boardTransition0;
+    BoardTransition boardTransition1;
+    BoardTransition boardTransition2;
+    string fromStr0;
+    string fromStr1;
+    string toStr0;
+    string toStr1;
+
+    public LastMoveClassifierTests()
+    {
+        board = new MoveWorker(Chessboard.StandardChessboard(), Piece.AllStandardPieces());
+        fromStr0 = "e2";
+        toStr0 = "e3";
+
+        fromStr1 = "e7";
+        toStr1 = "e6";
+
+        Move move0 = new Move(fromStr0 + toStr0, PieceClassifier.WHITE);
+        Move move1 = new Move(fromStr1 + toStr1, PieceClassifier.BLACK);
+
+        boardTransition0 = new BoardTransition(board, move0);
+        boardTransition1 = new BoardTransition(boardTransition0.NextState, move1);
+        boardTransition2 = new BoardTransition(boardTransition1.NextState, move1);
+    }
+
+    [Fact]
+    public void LastMoveWasWhite_ShouldReturnTrue()
+    {
+        IPredicate lastMoveWasWhite = new LastMoveClassifier(PieceClassifier.WHITE);
+        Assert.True(lastMoveWasWhite.Evaluate(boardTransition1));
+    }
+    [Fact]
+    public void LastMoveWasBlack_ShouldReturnFalse()
+    {
+        IPredicate lastMoveWasWhite = new LastMoveClassifier(PieceClassifier.BLACK);
+        Assert.False(lastMoveWasWhite.Evaluate(boardTransition1));
+    }
+
+
+    [Fact]
+    public void LastMoveWasBlack_ShouldReturnTrue()
+    {
+        IPredicate lastMoveWasWhite = new LastMoveClassifier(PieceClassifier.BLACK);
+        Assert.True(lastMoveWasWhite.Evaluate(boardTransition2));
+    }
+    [Fact]
+    public void LastMoveWasWhite_ShouldReturnFalse()
+    {
+        IPredicate lastMoveWasWhite = new LastMoveClassifier(PieceClassifier.WHITE);
+        Assert.False(lastMoveWasWhite.Evaluate(boardTransition2));
+    }
+}

--- a/ChessVariantsLogic.Tests/RulesTests/ChessPredicateTests/LastMoveTests.cs
+++ b/ChessVariantsLogic.Tests/RulesTests/ChessPredicateTests/LastMoveTests.cs
@@ -26,8 +26,8 @@ public class LastMoveTests
         toStr1 = "e4";
         from = new PositionAbsolute(fromStr);
         to = new PositionAbsolute(toStr0);
-        Move move0 = new Move(fromStr + toStr0);
-        Move move1 = new Move(toStr0 + toStr1);
+        Move move0 = new Move(fromStr + toStr0, PieceClassifier.WHITE);
+        Move move1 = new Move(toStr0 + toStr1, PieceClassifier.WHITE);
 
         boardTransition0 = new BoardTransition(board, move0);
         boardTransition1 = new BoardTransition(boardTransition0.NextState, move1);
@@ -38,6 +38,7 @@ public class LastMoveTests
     {
         IPredicate lastMoveWasE2E3 = new LastMove(from, to);
         Assert.True(lastMoveWasE2E3.Evaluate(boardTransition1));
+        //Assert.Equal("e2e3", boardTransition1.ThisState.getLastMove().FromTo);
     }
     [Fact]
     public void LastMoveWasE2E3_ShouldReturnFalse()

--- a/ChessVariantsLogic.Tests/RulesTests/ChessPredicateTests/PieceAtTests.cs
+++ b/ChessVariantsLogic.Tests/RulesTests/ChessPredicateTests/PieceAtTests.cs
@@ -14,7 +14,7 @@ public class PieceAtTests : IDisposable {
     public PieceAtTests()
     {
         board = new MoveWorker(Chessboard.StandardChessboard(), Piece.AllStandardPieces());
-        boardTransition = new BoardTransition(board, new Move("a1a1"));
+        boardTransition = new BoardTransition(board, new Move("a1a1", PieceClassifier.WHITE));
     }
 
     public void Dispose()

--- a/ChessVariantsLogic.Tests/RulesTests/ChessPredicateTests/PieceCapturedTests.cs
+++ b/ChessVariantsLogic.Tests/RulesTests/ChessPredicateTests/PieceCapturedTests.cs
@@ -31,8 +31,8 @@ public class PieceCapturedTests {
         board.Move("f1c4");
         board.Move("g8f6");
 
-        pieceWasNotCapturedTransition = new BoardTransition(board, new Move("a2a3"));
-        pieceWasCapturedTransition = new BoardTransition(board, new Move("h5f7"));
+        pieceWasNotCapturedTransition = new BoardTransition(board, new Move("a2a3", PieceClassifier.WHITE));
+        pieceWasCapturedTransition = new BoardTransition(board, new Move("h5f7", PieceClassifier.WHITE));
     }
 
     [Fact]

--- a/ChessVariantsLogic.Tests/RulesTests/ChessPredicateTests/PieceMovedTests.cs
+++ b/ChessVariantsLogic.Tests/RulesTests/ChessPredicateTests/PieceMovedTests.cs
@@ -1,0 +1,38 @@
+using Xunit;
+using ChessVariantsLogic.Rules.Predicates;
+using ChessVariantsLogic.Rules.Predicates.ChessPredicates;
+using ChessVariantsLogic.Rules;
+using ChessVariantsLogic.Rules.Moves;
+
+namespace ChessVariantsLogic.Tests;
+
+public class PieceMovedTests
+{
+    MoveWorker board;
+    BoardTransition boardTransition;
+    string fromStr;
+    string toStr;
+
+    public PieceMovedTests()
+    {
+        board = new MoveWorker(Chessboard.StandardChessboard(), Piece.AllStandardPieces());
+        fromStr = "e2";
+        toStr = "e3";
+        Move move = new Move(fromStr + toStr, PieceClassifier.WHITE);
+        boardTransition = new BoardTransition(board, move);
+    }
+
+    [Fact]
+    public void PawnMoved_ShouldReturnTrue()
+    {
+        IPredicate pawnMoved = new PieceMoved(Constants.WhitePawnIdentifier);
+        Assert.True(pawnMoved.Evaluate(boardTransition));
+    }
+
+    [Fact]
+    public void QueenMoved_ShouldReturnFalse()
+    {
+        IPredicate queenMoved = new PieceMoved(Constants.WhiteQueenIdentifier);
+        Assert.False(queenMoved.Evaluate(boardTransition));
+    }
+}

--- a/ChessVariantsLogic.Tests/RulesTests/ChessPredicateTests/PiecesLeftTests.cs
+++ b/ChessVariantsLogic.Tests/RulesTests/ChessPredicateTests/PiecesLeftTests.cs
@@ -14,7 +14,7 @@ public class PiecesLeftTests : IDisposable {
     public PiecesLeftTests()
     {
         board = new MoveWorker(Chessboard.StandardChessboard(), Piece.AllStandardPieces());
-        boardTransition = new BoardTransition(board, new Move("a1a1"));
+        boardTransition = new BoardTransition(board, new Move("a1a1", PieceClassifier.WHITE));
     }
 
     public void Dispose()

--- a/ChessVariantsLogic.Tests/RulesTests/ChessPredicateTests/SquareAttackedTests.cs
+++ b/ChessVariantsLogic.Tests/RulesTests/ChessPredicateTests/SquareAttackedTests.cs
@@ -29,8 +29,8 @@ public class SquareAttackedTests : IDisposable {
         blackBishopOnE2 = new MoveWorker(Chessboard.StandardChessboard(), Piece.AllStandardPieces());
         blackBishopOnE2.Board.Insert(Constants.BlackBishopIdentifier, "e2");
 
-        whiteKingAttackedTransition = new BoardTransition(whiteKingAttackedBoard, new Move("a1a1"));
-        blackBishopOnE2Transition = new BoardTransition(blackBishopOnE2, new Move("a1a1"));
+        whiteKingAttackedTransition = new BoardTransition(whiteKingAttackedBoard, new Move("a1a1", PieceClassifier.WHITE));
+        blackBishopOnE2Transition = new BoardTransition(blackBishopOnE2, new Move("a1a1", PieceClassifier.WHITE));
 
     }
 

--- a/ChessVariantsLogic.Tests/RulesTests/OperatorTests.cs
+++ b/ChessVariantsLogic.Tests/RulesTests/OperatorTests.cs
@@ -18,7 +18,7 @@ public class OperatorTests : IDisposable {
         constTrue = new Const(true);
         constFalse = new Const(false);
         board = new MoveWorker(new Chessboard(8));
-        transition = new BoardTransition(board, new Move("a1a1"));
+        transition = new BoardTransition(board, new Move("a1a1", PieceClassifier.WHITE));
     }
 
     public void Dispose()

--- a/ChessVariantsLogic/Chessboard.cs
+++ b/ChessVariantsLogic/Chessboard.cs
@@ -156,6 +156,8 @@ public class Chessboard
 
         return chessboard;
     }
+
+    /// <returns> an instance of Chessboard with the duck chess set up. </returns>
     public static Chessboard DuckChessboard()
     {
         var chessboard = new Chessboard(8);

--- a/ChessVariantsLogic/Chessboard.cs
+++ b/ChessVariantsLogic/Chessboard.cs
@@ -156,6 +156,39 @@ public class Chessboard
 
         return chessboard;
     }
+    public static Chessboard DuckChessboard()
+    {
+        var chessboard = new Chessboard(8);
+
+        chessboard.board[0, 0] = Constants.BlackRookIdentifier;
+        chessboard.board[0, 1] = Constants.BlackKnightIdentifier;
+        chessboard.board[0, 2] = Constants.BlackBishopIdentifier;
+        chessboard.board[0, 3] = Constants.BlackQueenIdentifier;
+        chessboard.board[0, 4] = Constants.BlackKingIdentifier;
+        chessboard.board[0, 5] = Constants.BlackBishopIdentifier;
+        chessboard.board[0, 6] = Constants.BlackKnightIdentifier;
+        chessboard.board[0, 7] = Constants.BlackRookIdentifier;
+
+        chessboard.fillRank(1, Constants.BlackPawnIdentifier);
+        chessboard.fillRank(2, Constants.UnoccupiedSquareIdentifier);
+        chessboard.fillRank(3, Constants.UnoccupiedSquareIdentifier);
+        chessboard.fillRank(4, Constants.UnoccupiedSquareIdentifier);
+        chessboard.fillRank(5, Constants.UnoccupiedSquareIdentifier);
+        chessboard.fillRank(6, Constants.WhitePawnIdentifier);
+
+        chessboard.board[7, 0] = Constants.WhiteRookIdentifier;
+        chessboard.board[7, 1] = Constants.WhiteKnightIdentifier;
+        chessboard.board[7, 2] = Constants.WhiteBishopIdentifier;
+        chessboard.board[7, 3] = Constants.WhiteQueenIdentifier;
+        chessboard.board[7, 4] = Constants.WhiteKingIdentifier;
+        chessboard.board[7, 5] = Constants.WhiteBishopIdentifier;
+        chessboard.board[7, 6] = Constants.WhiteKnightIdentifier;
+        chessboard.board[7, 7] = Constants.WhiteRookIdentifier;
+
+        chessboard.board[4, 4] = Constants.DuckIdentifier;
+
+        return chessboard;
+    }
 
     public Tuple<int, int>? ParseCoordinate(string coor)
     {

--- a/ChessVariantsLogic/Chessboard.cs
+++ b/ChessVariantsLogic/Chessboard.cs
@@ -160,33 +160,8 @@ public class Chessboard
     /// <returns> an instance of Chessboard with the duck chess set up. </returns>
     public static Chessboard DuckChessboard()
     {
-        var chessboard = new Chessboard(8);
-
-        chessboard.board[0, 0] = Constants.BlackRookIdentifier;
-        chessboard.board[0, 1] = Constants.BlackKnightIdentifier;
-        chessboard.board[0, 2] = Constants.BlackBishopIdentifier;
-        chessboard.board[0, 3] = Constants.BlackQueenIdentifier;
-        chessboard.board[0, 4] = Constants.BlackKingIdentifier;
-        chessboard.board[0, 5] = Constants.BlackBishopIdentifier;
-        chessboard.board[0, 6] = Constants.BlackKnightIdentifier;
-        chessboard.board[0, 7] = Constants.BlackRookIdentifier;
-
-        chessboard.fillRank(1, Constants.BlackPawnIdentifier);
-        chessboard.fillRank(2, Constants.UnoccupiedSquareIdentifier);
-        chessboard.fillRank(3, Constants.UnoccupiedSquareIdentifier);
-        chessboard.fillRank(4, Constants.UnoccupiedSquareIdentifier);
-        chessboard.fillRank(5, Constants.UnoccupiedSquareIdentifier);
-        chessboard.fillRank(6, Constants.WhitePawnIdentifier);
-
-        chessboard.board[7, 0] = Constants.WhiteRookIdentifier;
-        chessboard.board[7, 1] = Constants.WhiteKnightIdentifier;
-        chessboard.board[7, 2] = Constants.WhiteBishopIdentifier;
-        chessboard.board[7, 3] = Constants.WhiteQueenIdentifier;
-        chessboard.board[7, 4] = Constants.WhiteKingIdentifier;
-        chessboard.board[7, 5] = Constants.WhiteBishopIdentifier;
-        chessboard.board[7, 6] = Constants.WhiteKnightIdentifier;
-        chessboard.board[7, 7] = Constants.WhiteRookIdentifier;
-
+        var chessboard = StandardChessboard();
+        
         chessboard.board[4, 4] = Constants.DuckIdentifier;
 
         return chessboard;

--- a/ChessVariantsLogic/Constants.cs
+++ b/ChessVariantsLogic/Constants.cs
@@ -3,7 +3,7 @@ namespace ChessVariantsLogic;
 public static class Constants
 {
     public const int MaxBoardWidth = 20;
-    public const int MaxBoardHeigth = 20;
+    public const int MaxBoardHeight = 20;
 
     public const string BoardFiles = "abcdefghijklmnopqrst";
 

--- a/ChessVariantsLogic/Constants.cs
+++ b/ChessVariantsLogic/Constants.cs
@@ -23,9 +23,10 @@ public static class Constants
     public const string WhiteQueenIdentifier = "QU";
     public const string WhiteKingIdentifier = "KI";
     public const string WhitePawnIdentifier = "PA";
-#endregion
+    public const string DuckIdentifier = "DU";
+    #endregion
 
-#region Directions
+    #region Directions
     public static Tuple<int, int> North = new Tuple<int, int>(-1,0);
     public static Tuple<int, int> East = new Tuple<int, int>(0,1);
     public static Tuple<int, int> South = new Tuple<int, int>(1,0);

--- a/ChessVariantsLogic/GameFactory.cs
+++ b/ChessVariantsLogic/GameFactory.cs
@@ -115,14 +115,12 @@ public static class GameFactory
 
         IPredicate thisMoveWasDuckMove = new PieceMoved(Constants.DuckIdentifier);
 
-        IPredicate duckCaptured = new PieceCaptured(Constants.DuckIdentifier);
-
         IPredicate firstMove = new FirstMove();
 
-        IPredicate whiteMoveRule = ((thisMoveWasDuckMove & lastMoveWasWhite & !firstMove) | (!thisMoveWasDuckMove & (lastMoveWasDuck | firstMove))) & !duckCaptured;
+        IPredicate whiteMoveRule = ((thisMoveWasDuckMove & lastMoveWasWhite) | (!thisMoveWasDuckMove & (lastMoveWasDuck | firstMove)));
         IPredicate whiteWinRule = new PiecesLeft(Constants.BlackKingIdentifier, Comparator.EQUALS, 0, BoardState.THIS);
 
-        IPredicate blackMoveRule = ((thisMoveWasDuckMove & lastMoveWasBlack & !firstMove) | (!thisMoveWasDuckMove & (lastMoveWasDuck | firstMove))) & !duckCaptured;
+        IPredicate blackMoveRule = ((thisMoveWasDuckMove & lastMoveWasBlack) | (!thisMoveWasDuckMove & (lastMoveWasDuck | firstMove)));
         IPredicate blackWinRule = new PiecesLeft(Constants.WhiteKingIdentifier, Comparator.EQUALS, 0, BoardState.THIS);
 
         ISet<MoveTemplate> movesWhite = new HashSet<MoveTemplate>

--- a/ChessVariantsLogic/GameFactory.cs
+++ b/ChessVariantsLogic/GameFactory.cs
@@ -22,6 +22,7 @@ public static class GameFactory
     public const string StandardIdentifier = "standard";
     public const string CaptureTheKingIdentifier = "captureTheKing";
     public const string AntiChessIdentifier = "antiChess";
+    public const string DuckChessIdentifier = "duckChess";
 
     public static Game StandardChess()
     {
@@ -97,10 +98,56 @@ public static class GameFactory
         };
 
         RuleSet rulesWhite = new RuleSet(whiteMoveRule, whiteWinRule, movesWhite);
-        RuleSet rulesBlack = new RuleSet(whiteMoveRule, whiteWinRule, movesBlack);
+        RuleSet rulesBlack = new RuleSet(blackMoveRule, blackWinRule, movesBlack);
 
 
         return new Game(new MoveWorker(Chessboard.StandardChessboard(), Piece.AllStandardPieces()), Player.White, 1, rulesWhite, rulesBlack);
+
+    }
+
+
+    public static Game DuckChess()
+    {
+
+        IPredicate lastMoveWasDuck = new LastMoveClassifier(PieceClassifier.SHARED);
+        IPredicate lastMoveWasBlack = new LastMoveClassifier(PieceClassifier.BLACK);
+        IPredicate lastMoveWasWhite = new LastMoveClassifier(PieceClassifier.WHITE);
+
+        IPredicate thisMoveWasDuckMove = new PieceMoved(Constants.DuckIdentifier);
+
+        IPredicate duckCaptured = new PieceCaptured(Constants.DuckIdentifier);
+
+        IPredicate firstMove = new FirstMove();
+
+        IPredicate whiteMoveRule = ((thisMoveWasDuckMove & lastMoveWasWhite & !firstMove) | (!thisMoveWasDuckMove & (lastMoveWasDuck | firstMove))) & !duckCaptured;
+        IPredicate whiteWinRule = new PiecesLeft(Constants.BlackKingIdentifier, Comparator.EQUALS, 0, BoardState.THIS);
+
+        IPredicate blackMoveRule = ((thisMoveWasDuckMove & lastMoveWasBlack & !firstMove) | (!thisMoveWasDuckMove & (lastMoveWasDuck | firstMove))) & !duckCaptured;
+        IPredicate blackWinRule = new PiecesLeft(Constants.WhiteKingIdentifier, Comparator.EQUALS, 0, BoardState.THIS);
+
+        ISet<MoveTemplate> movesWhite = new HashSet<MoveTemplate>
+        {
+            MoveTemplate.CastleMove(Player.White, true, true),
+            MoveTemplate.CastleMove(Player.White, false, true),
+            MoveTemplate.PawnDoubleMove(Player.White),
+            MoveTemplate.EnPassantMove(Player.White, true),
+            MoveTemplate.EnPassantMove(Player.White, false),
+        };
+
+        ISet<MoveTemplate> movesBlack = new HashSet<MoveTemplate>
+        {
+            MoveTemplate.CastleMove(Player.Black, true, true),
+            MoveTemplate.CastleMove(Player.Black, false, true),
+            MoveTemplate.PawnDoubleMove(Player.Black),
+            MoveTemplate.EnPassantMove(Player.Black, true),
+            MoveTemplate.EnPassantMove(Player.Black, false),
+        };
+
+        RuleSet rulesWhite = new RuleSet(whiteMoveRule, whiteWinRule, movesWhite);
+        RuleSet rulesBlack = new RuleSet(blackMoveRule, blackWinRule, movesBlack);
+
+
+        return new Game(new MoveWorker(Chessboard.DuckChessboard(), Piece.AllDuckChessPieces()), Player.White, 2, rulesWhite, rulesBlack);
 
     }
 
@@ -132,6 +179,7 @@ public static class GameFactory
             StandardIdentifier => StandardChess(),
             AntiChessIdentifier => AntiChess(),
             CaptureTheKingIdentifier => CaptureTheKing(),
+            DuckChessIdentifier => DuckChess(),
             _ => throw new ArgumentException($"No variant corresponds to identifier: {identifier}"),
         };
 

--- a/ChessVariantsLogic/Movement/MoveWorker.cs
+++ b/ChessVariantsLogic/Movement/MoveWorker.cs
@@ -1,5 +1,6 @@
 namespace ChessVariantsLogic;
 using System;
+using ChessVariantsLogic.Rules.Moves;
 
 /// <summary>
 /// Retrieves and performs valid moves on a given Chessboard.
@@ -20,9 +21,9 @@ public class MoveWorker
 
     private readonly Dictionary<string, Piece> stringToPiece;
 
-    private readonly List<string> movelog = new List<string>();
+    private readonly List<Move> movelog = new List<Move>();
 
-    public List<string> Movelog
+    public List<Move> Movelog
     {
         get { return movelog; }
     }
@@ -73,13 +74,17 @@ public class MoveWorker
                 board.Insert(strPiece, to);
                 board.Insert(Constants.UnoccupiedSquareIdentifier, from);
                 board.PieceHasMoved(coor.Item1,coor.Item2);
-                movelog.Add(move);
                 return GameEvent.MoveSucceeded;
             }
         }
         catch (KeyNotFoundException) { }
         
         return GameEvent.InvalidMove;
+    }
+
+    public void AddMove(Move move)
+    {
+        movelog.Add(move);
     }
 
     /// <summary>
@@ -169,6 +174,13 @@ public class MoveWorker
             }
         }
         return coorSetToStringSet(coorMoves);
+    }
+
+
+    public PieceClassifier GetPieceClassifier(string pieceIdentifier)
+    {
+        Piece p = stringToPiece[pieceIdentifier];
+        return p.PieceClassifier;
     }
 
     /// <inheritdoc/>
@@ -544,7 +556,8 @@ public class MoveWorker
     private bool pieceBelongsToPlayer(Piece piece, Player player)
     {
         return player.Equals(Player.White) && piece.PieceClassifier.Equals(PieceClassifier.WHITE)
-            || player.Equals(Player.Black) && piece.PieceClassifier.Equals(PieceClassifier.BLACK);
+            || player.Equals(Player.Black) && piece.PieceClassifier.Equals(PieceClassifier.BLACK)
+            || piece.PieceClassifier.Equals(PieceClassifier.SHARED);
     }
     
     private bool insideBoard(int row, int col)
@@ -590,7 +603,7 @@ public class MoveWorker
     /// <summary>
     /// Returns the last move from the movelog
     /// </summary>
-    public string? getLastMove()
+    public Move? getLastMove()
     {
         if (Movelog.Count == 0)
             return null;

--- a/ChessVariantsLogic/Movement/MoveWorker.cs
+++ b/ChessVariantsLogic/Movement/MoveWorker.cs
@@ -82,6 +82,9 @@ public class MoveWorker
         return GameEvent.InvalidMove;
     }
 
+    /// <summary>
+    /// Adds the given move to the internal movelog. 
+    /// </summary>
     public void AddMove(Move move)
     {
         movelog.Add(move);
@@ -92,7 +95,7 @@ public class MoveWorker
     /// </summary>
     /// <param name="move"> is a string representing two coordinates on the chessboard.</param>
     /// <returns> the two squares split into separate strings. </returns>
-    public Tuple<string, string>? ParseMove(string move)
+    public static Tuple<string, string>? ParseMove(string move)
     {
         string from = "", to = "";
         switch (move.Length)
@@ -176,6 +179,10 @@ public class MoveWorker
         return coorSetToStringSet(coorMoves);
     }
 
+
+    /// <summary>
+    /// <returns>The classifier of the given pieceIdentifier</returns>
+    /// </summary>
 
     public PieceClassifier GetPieceClassifier(string pieceIdentifier)
     {

--- a/ChessVariantsLogic/Piece.cs
+++ b/ChessVariantsLogic/Piece.cs
@@ -261,6 +261,27 @@ public class Piece
         return new Piece(mp, cp, false, PieceClassifier.WHITE, Constants.WhitePawnIdentifier);
     }
 
+    public static Piece Duck(int boardWidth, int boardHeight)
+    {
+        var capturePatterns = new List<IPattern> {
+        };
+        var patterns = new List<IPattern> {
+        };
+
+        for (int i = -boardWidth; i < boardWidth; i++)
+        {
+            for (int j = -boardHeight; j < boardHeight; j++)
+            {
+                if (i == 0 && j == 0) continue;
+                patterns.Add(new JumpPattern(i, j));
+            }
+        }
+
+        var mp = new MovementPattern(patterns);
+        var cp = new MovementPattern(capturePatterns);
+        return new Piece(mp, cp, false, PieceClassifier.SHARED, Constants.DuckIdentifier);
+    }
+
     /// <summary>
     /// Instantiates a HashSet of all the standard pieces.
     /// </summary>
@@ -277,7 +298,20 @@ public class Piece
             WhitePawn(), BlackPawn()
         };
     }
-    
-#endregion
+
+    public static HashSet<Piece> AllDuckChessPieces()
+    {
+        return new HashSet<Piece>
+        {
+            Rook(PieceClassifier.WHITE), Rook(PieceClassifier.BLACK),
+            Knight(PieceClassifier.WHITE), Knight(PieceClassifier.BLACK),
+            Bishop(PieceClassifier.WHITE), Bishop(PieceClassifier.BLACK),
+            Queen(PieceClassifier.WHITE), Queen(PieceClassifier.BLACK),
+            King(PieceClassifier.WHITE), King(PieceClassifier.BLACK),
+            WhitePawn(), BlackPawn(), Duck(8, 8)
+        };
+    }
+
+    #endregion
 
 }

--- a/ChessVariantsLogic/Piece.cs
+++ b/ChessVariantsLogic/Piece.cs
@@ -9,6 +9,7 @@ public class Piece
     private readonly MovementPattern movementPattern;
     private readonly MovementPattern capturePattern;
     private readonly bool royal;
+    private readonly bool canBeCaptured;
     private readonly PieceClassifier pieceClassifier;
     private bool hasMoved;
 
@@ -36,6 +37,11 @@ public class Piece
         get { return this.pieceIdentifier; }
     }
 
+    public bool CanBeCaptured
+    {
+        get { return this.canBeCaptured; }
+    }
+
     /// <summary>
     /// Constructor for a new Piece.
     /// </summary>
@@ -46,7 +52,7 @@ public class Piece
     /// <param name="hasMoved">set true if the piece has previously moved</param>
     /// <param name="repeat">is the amount of times the movement pattern can be repeated on the same turn</param>
     /// <param name="pieceIdentifier">is the unique string representation of the piece</param>
-    public Piece(MovementPattern movementPattern, MovementPattern capturePattern, bool royal, PieceClassifier pc, bool hasMoved, int repeat, string pieceIdentifier)
+    public Piece(MovementPattern movementPattern, MovementPattern capturePattern, bool royal, PieceClassifier pc, bool hasMoved, int repeat, string pieceIdentifier, bool canBeCaptured)
     {
         this.movementPattern = movementPattern;
         this.capturePattern = capturePattern;
@@ -55,13 +61,14 @@ public class Piece
         this.hasMoved = hasMoved;
         this.repeat = repeat;
         this.pieceIdentifier = pieceIdentifier;
+        this.canBeCaptured = canBeCaptured;
     }
 
-    public Piece(MovementPattern movementPattern, MovementPattern capturePattern, bool royal, PieceClassifier pc, int repeat, string pieceIdentifier)
-    : this(movementPattern, capturePattern, royal, pc, false, repeat, pieceIdentifier) {}
+    public Piece(MovementPattern movementPattern, MovementPattern capturePattern, bool royal, PieceClassifier pc, int repeat, string pieceIdentifier, bool canBeCaptured = true)
+    : this(movementPattern, capturePattern, royal, pc, false, repeat, pieceIdentifier, canBeCaptured) {}
     
-    public Piece(MovementPattern movementPattern, MovementPattern capturePattern, bool royal, PieceClassifier pc, string pieceIdentifier)
-    : this(movementPattern, capturePattern, royal, pc, false, 0, pieceIdentifier) {}
+    public Piece(MovementPattern movementPattern, MovementPattern capturePattern, bool royal, PieceClassifier pc, string pieceIdentifier, bool canBeCaptured = true)
+    : this(movementPattern, capturePattern, royal, pc, false, 0, pieceIdentifier, canBeCaptured) {}
 
 #endregion
 
@@ -104,13 +111,13 @@ public class Piece
     }
 
     /// <summary>
-    /// Checks that this and <paramref name="other"/> are of opposite colors.
+    /// Checks that this and <paramref name="other"/> are of opposite colors and that <paramref name="other"/> can be captured.
     /// </summary>
     /// <param name="other"> is the other piece</param>
     /// <returns> true if this is of opposite color than other, otherwise false.</returns>
     public bool CanTake(Piece other)
     {
-        return !this.pieceClassifier.Equals(other.pieceClassifier);
+        return !this.pieceClassifier.Equals(other.pieceClassifier) && other.CanBeCaptured;
     }
 
 #region Static methods
@@ -123,10 +130,10 @@ public class Piece
     public static Piece Rook(PieceClassifier pieceClassifier)
     {
         var patterns = new List<IPattern> {
-            new RegularPattern(Constants.North, 1, Constants.MaxBoardHeigth),
-            new RegularPattern(Constants.East,  1, Constants.MaxBoardHeigth),
-            new RegularPattern(Constants.South, 1, Constants.MaxBoardHeigth),
-            new RegularPattern(Constants.West,  1, Constants.MaxBoardHeigth)
+            new RegularPattern(Constants.North, 1, Constants.MaxBoardHeight),
+            new RegularPattern(Constants.East,  1, Constants.MaxBoardHeight),
+            new RegularPattern(Constants.South, 1, Constants.MaxBoardHeight),
+            new RegularPattern(Constants.West,  1, Constants.MaxBoardHeight)
         };
         var mp = new MovementPattern(patterns);
 
@@ -143,10 +150,10 @@ public class Piece
     public static Piece Bishop(PieceClassifier pieceClassifier)
     {
         var patterns = new List<IPattern> {
-            new RegularPattern(Constants.NorthEast,  1, Constants.MaxBoardHeigth),
-            new RegularPattern(Constants.SouthEast,  1, Constants.MaxBoardHeigth),
-            new RegularPattern(Constants.SouthWest,  1, Constants.MaxBoardHeigth),
-            new RegularPattern(Constants.NorthWest,  1, Constants.MaxBoardHeigth)
+            new RegularPattern(Constants.NorthEast,  1, Constants.MaxBoardHeight),
+            new RegularPattern(Constants.SouthEast,  1, Constants.MaxBoardHeight),
+            new RegularPattern(Constants.SouthWest,  1, Constants.MaxBoardHeight),
+            new RegularPattern(Constants.NorthWest,  1, Constants.MaxBoardHeight)
         };
         var mp = new MovementPattern(patterns);
 
@@ -163,14 +170,14 @@ public class Piece
     public static Piece Queen(PieceClassifier pieceClassifier)
     {
         var patterns = new List<IPattern> {
-            new RegularPattern(Constants.North,     1, Constants.MaxBoardHeigth),
-            new RegularPattern(Constants.NorthEast, 1, Constants.MaxBoardHeigth),
-            new RegularPattern(Constants.East,      1, Constants.MaxBoardHeigth),
-            new RegularPattern(Constants.SouthEast, 1, Constants.MaxBoardHeigth),
-            new RegularPattern(Constants.South,     1, Constants.MaxBoardHeigth),
-            new RegularPattern(Constants.SouthWest, 1, Constants.MaxBoardHeigth),
-            new RegularPattern(Constants.West,      1, Constants.MaxBoardHeigth),
-            new RegularPattern(Constants.NorthWest, 1, Constants.MaxBoardHeigth)
+            new RegularPattern(Constants.North,     1, Constants.MaxBoardHeight),
+            new RegularPattern(Constants.NorthEast, 1, Constants.MaxBoardHeight),
+            new RegularPattern(Constants.East,      1, Constants.MaxBoardHeight),
+            new RegularPattern(Constants.SouthEast, 1, Constants.MaxBoardHeight),
+            new RegularPattern(Constants.South,     1, Constants.MaxBoardHeight),
+            new RegularPattern(Constants.SouthWest, 1, Constants.MaxBoardHeight),
+            new RegularPattern(Constants.West,      1, Constants.MaxBoardHeight),
+            new RegularPattern(Constants.NorthWest, 1, Constants.MaxBoardHeight)
         };
         var mp = new MovementPattern(patterns);
 
@@ -261,16 +268,20 @@ public class Piece
         return new Piece(mp, cp, false, PieceClassifier.WHITE, Constants.WhitePawnIdentifier);
     }
 
-    public static Piece Duck(int boardWidth, int boardHeight)
+    /// <summary>
+    /// Creates a Piece object that behaves like a duck.
+    /// </summary>
+    /// <returns>an instance of Piece with the movement pattern of a duck.</returns>
+    public static Piece Duck()
     {
         var capturePatterns = new List<IPattern> {
         };
         var patterns = new List<IPattern> {
         };
 
-        for (int i = -boardWidth; i < boardWidth; i++)
+        for (int i = -Constants.MaxBoardWidth; i < Constants.MaxBoardWidth; i++)
         {
-            for (int j = -boardHeight; j < boardHeight; j++)
+            for (int j = -Constants.MaxBoardHeight; j < Constants.MaxBoardHeight; j++)
             {
                 if (i == 0 && j == 0) continue;
                 patterns.Add(new JumpPattern(i, j));
@@ -279,7 +290,7 @@ public class Piece
 
         var mp = new MovementPattern(patterns);
         var cp = new MovementPattern(capturePatterns);
-        return new Piece(mp, cp, false, PieceClassifier.SHARED, Constants.DuckIdentifier);
+        return new Piece(mp, cp, false, PieceClassifier.SHARED, Constants.DuckIdentifier, false);
     }
 
     /// <summary>
@@ -299,6 +310,10 @@ public class Piece
         };
     }
 
+    /// <summary>
+    /// Instantiates a HashSet of all the standard pieces and the duck piece.
+    /// </summary>
+    /// <returns>A HashSet containing all the standard pieces and the duck piece.</returns>
     public static HashSet<Piece> AllDuckChessPieces()
     {
         return new HashSet<Piece>
@@ -308,7 +323,7 @@ public class Piece
             Bishop(PieceClassifier.WHITE), Bishop(PieceClassifier.BLACK),
             Queen(PieceClassifier.WHITE), Queen(PieceClassifier.BLACK),
             King(PieceClassifier.WHITE), King(PieceClassifier.BLACK),
-            WhitePawn(), BlackPawn(), Duck(8, 8)
+            WhitePawn(), BlackPawn(), Duck()
         };
     }
 

--- a/ChessVariantsLogic/Piece.cs
+++ b/ChessVariantsLogic/Piece.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+
 namespace ChessVariantsLogic;
 
 /// <summary>
@@ -316,15 +318,9 @@ public class Piece
     /// <returns>A HashSet containing all the standard pieces and the duck piece.</returns>
     public static HashSet<Piece> AllDuckChessPieces()
     {
-        return new HashSet<Piece>
-        {
-            Rook(PieceClassifier.WHITE), Rook(PieceClassifier.BLACK),
-            Knight(PieceClassifier.WHITE), Knight(PieceClassifier.BLACK),
-            Bishop(PieceClassifier.WHITE), Bishop(PieceClassifier.BLACK),
-            Queen(PieceClassifier.WHITE), Queen(PieceClassifier.BLACK),
-            King(PieceClassifier.WHITE), King(PieceClassifier.BLACK),
-            WhitePawn(), BlackPawn(), Duck()
-        };
+        HashSet<Piece> pieces = AllStandardPieces();
+        pieces.Add(Duck());
+        return pieces;
     }
 
     #endregion

--- a/ChessVariantsLogic/Rules/BoardTransition.cs
+++ b/ChessVariantsLogic/Rules/BoardTransition.cs
@@ -21,7 +21,7 @@ public class BoardTransition
         Move = move;
         Result = Move.Perform(NextState);
 
-        Tuple<string, string>? fromTo = thisState.ParseMove(move.FromTo);
+        Tuple<string, string>? fromTo = MoveWorker.ParseMove(move.FromTo);
         if (fromTo == null) throw new ArgumentException("The given move parameter does not contain a proper move string. Supplied move string: " + move.FromTo);
 
         MoveFrom = fromTo.Item1;

--- a/ChessVariantsLogic/Rules/Moves/Actions/ActionMovePiece.cs
+++ b/ChessVariantsLogic/Rules/Moves/Actions/ActionMovePiece.cs
@@ -21,6 +21,13 @@ public class ActionMovePiece : IAction
         _to = to;
     }
 
+    public ActionMovePiece(string fromTo)
+    {
+        var (from, to) = MoveWorker.ParseMove(fromTo);
+        _from = new PositionAbsolute(from);
+        _to = new PositionAbsolute(to);
+    }
+
     /// <summary>
     /// Forcefully move a piece on the board according to the given positions.
     /// If Positions are defined as relative, it will be calculated relative to the piece performing the action.

--- a/ChessVariantsLogic/Rules/Moves/Move.cs
+++ b/ChessVariantsLogic/Rules/Moves/Move.cs
@@ -12,28 +12,31 @@ public class Move
     private readonly IEnumerable<IAction>? _actions;
     private readonly string _fromTo;
 
-    public string FromTo => _fromTo;
 
+    public string FromTo => _fromTo;
+    public readonly PieceClassifier Player;
 
     /// <summary>
     /// Constructor that takes a list of actions and a string fromTo.
     /// </summary>
     /// <param name="actions">The list of actions that the move performs.</param>
     /// <param name="fromTo">A pair of coordinates, the position of the performing piece and where it ends up.</param>
-    public Move(IEnumerable<IAction>? actions, string fromTo)
+    public Move(IEnumerable<IAction>? actions, string fromTo, PieceClassifier player)
     {
         _actions = actions;
         _fromTo = fromTo;
+        Player = player;
     }
 
     /// <summary>
     /// Constructs a standard move.
     /// </summary>
     /// <param name="fromTo">A pair of coordinates, the position of the piece to be moved and where it ends up.</param>
-    public Move(string fromTo)
+    public Move(string fromTo, PieceClassifier pieceClassifier)
     {
         _actions = null;
         _fromTo = fromTo;
+        Player = pieceClassifier;
     }
 
     /// <summary>
@@ -51,6 +54,7 @@ public class Move
         if (fromTo == null) throw new ArgumentException("Move needs to contain proper fromTo coordinate, supplied fromTo coordinate: " + _fromTo);
         if(_actions == null)
         {
+            moveWorker.AddMove(this);
             return moveWorker.Move(_fromTo);
         }
         foreach (var action in _actions)
@@ -59,6 +63,7 @@ public class Move
             if(gameEvent == GameEvent.InvalidMove)
                 return GameEvent.InvalidMove;
         }
+        moveWorker.AddMove(this);
         return GameEvent.MoveSucceeded;
     }
 

--- a/ChessVariantsLogic/Rules/Moves/MoveTemplate.cs
+++ b/ChessVariantsLogic/Rules/Moves/MoveTemplate.cs
@@ -40,6 +40,7 @@ public class MoveTemplate
     public IEnumerable<Move> GetValidMoves(MoveWorker thisBoard, IPredicate moveRule)
     {
         List<string> positions = (List<string>) Utils.FindPiecesOfType(thisBoard, _pieceIdentifier);
+        PieceClassifier pieceClassifier = thisBoard.GetPieceClassifier(_pieceIdentifier);
         HashSet<Move> moves = new HashSet<Move>();
 
         foreach(string from in positions)
@@ -47,7 +48,7 @@ public class MoveTemplate
             string? to = _to.GetPosition(thisBoard, from);
             if (to == null) continue;
 
-            Move move = new Move(_actions, from + to);
+            Move move = new Move(_actions, from + to, pieceClassifier);
             
             BoardTransition transition = new BoardTransition(thisBoard, move);
             if(_predicate.Evaluate(transition) && moveRule.Evaluate(transition) && transition.IsValid())

--- a/ChessVariantsLogic/Rules/Predicates/ChessPredicates/FirstMove.cs
+++ b/ChessVariantsLogic/Rules/Predicates/ChessPredicates/FirstMove.cs
@@ -2,13 +2,13 @@
 using ChessVariantsLogic.Rules.Moves;
 
 /// <summary>
-/// This predicate evaluates if the last move is equal to the compare values.
+/// This predicate evaluates if this is the first move i.e the movelog is empy.
 /// </summary>
 public class FirstMove : IPredicate
 {
 
     public bool Evaluate(BoardTransition transition)
     {
-        return transition.ThisState.getLastMove() == null;
+        return transition.ThisState.Movelog.Count == 0;
     }
 }

--- a/ChessVariantsLogic/Rules/Predicates/ChessPredicates/FirstMove.cs
+++ b/ChessVariantsLogic/Rules/Predicates/ChessPredicates/FirstMove.cs
@@ -1,0 +1,14 @@
+﻿namespace ChessVariantsLogic.Rules.Predicates.ChessPredicates;
+using ChessVariantsLogic.Rules.Moves;
+
+/// <summary>
+/// This predicate evaluates if the last move is equal to the compare values.
+/// </summary>
+public class FirstMove : IPredicate
+{
+
+    public bool Evaluate(BoardTransition transition)
+    {
+        return transition.ThisState.getLastMove() == null;
+    }
+}

--- a/ChessVariantsLogic/Rules/Predicates/ChessPredicates/ForEvery.cs
+++ b/ChessVariantsLogic/Rules/Predicates/ChessPredicates/ForEvery.cs
@@ -26,7 +26,10 @@ public class ForEvery : IPredicate
         var possibleMoves = transition.NextState.GetAllValidMoves(_player);
         foreach (var moveCoordinates in possibleMoves)
         {
-            Move move = new Move(moveCoordinates);
+            var (from, _) = transition.NextState.ParseMove(moveCoordinates);
+
+            var pieceIdentifier = transition.NextState.Board.GetPieceIdentifier(from);
+            Move move = new Move(moveCoordinates, transition.NextState.GetPieceClassifier(pieceIdentifier));
             BoardTransition newTransition = new BoardTransition(transition.NextState, move);
             bool ruleSatisfied = _rule.Evaluate(newTransition);
             if (!ruleSatisfied)

--- a/ChessVariantsLogic/Rules/Predicates/ChessPredicates/ForEvery.cs
+++ b/ChessVariantsLogic/Rules/Predicates/ChessPredicates/ForEvery.cs
@@ -26,7 +26,7 @@ public class ForEvery : IPredicate
         var possibleMoves = transition.NextState.GetAllValidMoves(_player);
         foreach (var moveCoordinates in possibleMoves)
         {
-            var (from, _) = transition.NextState.ParseMove(moveCoordinates);
+            var (from, _) = MoveWorker.ParseMove(moveCoordinates);
 
             var pieceIdentifier = transition.NextState.Board.GetPieceIdentifier(from);
             Move move = new Move(moveCoordinates, transition.NextState.GetPieceClassifier(pieceIdentifier));

--- a/ChessVariantsLogic/Rules/Predicates/ChessPredicates/LastMove.cs
+++ b/ChessVariantsLogic/Rules/Predicates/ChessPredicates/LastMove.cs
@@ -1,4 +1,5 @@
 ﻿namespace ChessVariantsLogic.Rules.Predicates.ChessPredicates;
+using ChessVariantsLogic.Rules.Moves;
 
 /// <summary>
 /// This predicate evaluates if the last move is equal to the compare values.
@@ -16,11 +17,13 @@ public class LastMove : IPredicate
 
     public bool Evaluate(BoardTransition transition)
     {
-        string? lastMove = transition.ThisState.getLastMove();
+        Move? move = transition.ThisState.getLastMove();
+        if (move == null) return false;
+        string lastMove = move.FromTo;
         string? from = _compareFrom.GetPosition(transition.ThisState, transition.MoveFrom);
         string? to   = _compareTo.GetPosition(transition.ThisState, transition.MoveFrom);
 
-        if (lastMove == null || from == null || to == null) return false;
+        if (from == null || to == null) return false;
         string compareMove = from + to;
         return compareMove == lastMove;
     }

--- a/ChessVariantsLogic/Rules/Predicates/ChessPredicates/LastMoveClassifier.cs
+++ b/ChessVariantsLogic/Rules/Predicates/ChessPredicates/LastMoveClassifier.cs
@@ -1,0 +1,23 @@
+﻿namespace ChessVariantsLogic.Rules.Predicates.ChessPredicates;
+using ChessVariantsLogic.Rules.Moves;
+
+/// <summary>
+/// This predicate evaluates if the last move is equal to the compare values.
+/// </summary>
+public class LastMoveClassifier : IPredicate
+{
+    private readonly PieceClassifier _pieceClassifier;
+
+    public LastMoveClassifier(PieceClassifier pieceClassifier)
+    {
+        _pieceClassifier = pieceClassifier;
+    }
+
+    public bool Evaluate(BoardTransition transition)
+    {
+        Move? move = transition.ThisState.getLastMove();
+        if (move == null) return false;
+        PieceClassifier lastMovePlayer = move.Player;
+        return _pieceClassifier == lastMovePlayer;
+    }
+}

--- a/ChessVariantsLogic/Rules/Predicates/ChessPredicates/LastMoveClassifier.cs
+++ b/ChessVariantsLogic/Rules/Predicates/ChessPredicates/LastMoveClassifier.cs
@@ -2,7 +2,7 @@
 using ChessVariantsLogic.Rules.Moves;
 
 /// <summary>
-/// This predicate evaluates if the last move is equal to the compare values.
+/// This predicate evaluates if the piece performing the last move has the same classifier as the internal _pieceClassifier.
 /// </summary>
 public class LastMoveClassifier : IPredicate
 {
@@ -17,7 +17,7 @@ public class LastMoveClassifier : IPredicate
     {
         Move? move = transition.ThisState.getLastMove();
         if (move == null) return false;
-        PieceClassifier lastMovePlayer = move.Player;
+        PieceClassifier lastMovePlayer = move.PieceClassifier;
         return _pieceClassifier == lastMovePlayer;
     }
 }

--- a/ChessVariantsLogic/Rules/Predicates/ChessPredicates/PieceCaptured.cs
+++ b/ChessVariantsLogic/Rules/Predicates/ChessPredicates/PieceCaptured.cs
@@ -13,10 +13,10 @@ public class PieceCaptured : IPredicate
     }
 
     /// <summary>
-    /// Returns true if a piece was captured when transitioning from <paramref name="thisBoardState"/> to <paramref name="nextBoardState"/>.
+    /// Returns true if a piece was captured during the given <paramref name="transition"/>.
     /// </summary>
     /// <inheritdoc/>
-    /// <returns>True if a piece was captured during transition from <paramref name="thisBoardState"/> to <paramref name="nextBoardState"/>.</returns>
+    /// <returns>True if a piece was captured during the given <paramref name="transition"/></returns>
     public bool Evaluate(BoardTransition transition)
     {
         int amountOfPieces = Utils.FindPiecesOfType(transition.ThisState, _pieceIdentifier).Count();
@@ -24,5 +24,4 @@ public class PieceCaptured : IPredicate
         int diff = amountOfPieces - amountOfPieces_nextState;
         return diff > 0;
     }
-
 }

--- a/ChessVariantsLogic/Rules/Predicates/ChessPredicates/PieceMoved.cs
+++ b/ChessVariantsLogic/Rules/Predicates/ChessPredicates/PieceMoved.cs
@@ -1,7 +1,7 @@
 ﻿namespace ChessVariantsLogic.Rules.Predicates.ChessPredicates;
 
 /// <summary>
-/// This predicate determines if a piece has been captured when transitioning to a new board state.
+/// This predicate determines if a piece with the internal _pieceIdentifier was moved during the board transition.
 /// </summary>
 public class PieceMoved : IPredicate
 {
@@ -12,11 +12,7 @@ public class PieceMoved : IPredicate
         _pieceIdentifier = pieceIdentifier;
     }
 
-    /// <summary>
-    /// Returns true if a piece was captured when transitioning from <paramref name="thisBoardState"/> to <paramref name="nextBoardState"/>.
-    /// </summary>
-    /// <inheritdoc/>
-    /// <returns>True if a piece was captured during transition from <paramref name="thisBoardState"/> to <paramref name="nextBoardState"/>.</returns>
+    
     public bool Evaluate(BoardTransition transition)
     {
         string piece = transition.ThisState.Board.GetPieceIdentifier(transition.MoveFrom);

--- a/ChessVariantsLogic/Rules/Predicates/ChessPredicates/PieceMoved.cs
+++ b/ChessVariantsLogic/Rules/Predicates/ChessPredicates/PieceMoved.cs
@@ -1,0 +1,27 @@
+﻿namespace ChessVariantsLogic.Rules.Predicates.ChessPredicates;
+
+/// <summary>
+/// This predicate determines if a piece has been captured when transitioning to a new board state.
+/// </summary>
+public class PieceMoved : IPredicate
+{
+    private readonly string _pieceIdentifier;
+
+    public PieceMoved(string pieceIdentifier)
+    {
+        _pieceIdentifier = pieceIdentifier;
+    }
+
+    /// <summary>
+    /// Returns true if a piece was captured when transitioning from <paramref name="thisBoardState"/> to <paramref name="nextBoardState"/>.
+    /// </summary>
+    /// <inheritdoc/>
+    /// <returns>True if a piece was captured during transition from <paramref name="thisBoardState"/> to <paramref name="nextBoardState"/>.</returns>
+    public bool Evaluate(BoardTransition transition)
+    {
+        string piece = transition.ThisState.Board.GetPieceIdentifier(transition.MoveFrom);
+
+        return (piece == _pieceIdentifier) && (transition.MoveFrom != transition.MoveTo);
+    }
+
+}

--- a/ChessVariantsLogic/Rules/Predicates/ChessPredicates/Utils.cs
+++ b/ChessVariantsLogic/Rules/Predicates/ChessPredicates/Utils.cs
@@ -22,7 +22,7 @@ public class Utils
         var attackedPieces = board.GetAllCaptureMoves(attacker);
         foreach (var attackerMove in attackedPieces)
         {
-            var (_, to) = board.ParseMove(attackerMove);
+            var (_, to) = MoveWorker.ParseMove(attackerMove);
             if (piecePositions.Contains(to))
             {
                 return true;
@@ -42,7 +42,7 @@ public class Utils
         var attackedPieces = board.GetAllCaptureMoves(attacker);
         foreach (var attackerMove in attackedPieces)
         {
-            var (_, to) = board.ParseMove(attackerMove);
+            var (_, to) = MoveWorker.ParseMove(attackerMove);
             if (position.Equals(to))
             {
                 return true;

--- a/ChessVariantsLogic/Rules/RuleSet.cs
+++ b/ChessVariantsLogic/Rules/RuleSet.cs
@@ -29,7 +29,7 @@ public class RuleSet
         var moves = ApplyMoveRule(board, player);
         foreach (var move in moves)
         {
-            var fromTo = board.ParseMove(move.FromTo);
+            var fromTo = MoveWorker.ParseMove(move.FromTo);
             if (fromTo == null)
             {
                 throw new InvalidOperationException($"Could not parse move {move}");
@@ -59,7 +59,7 @@ public class RuleSet
         var acceptedMoves = new List<Move>();
         foreach (var moveCoordinates in possibleMoves)
         {
-            var (from, _) = board.ParseMove(moveCoordinates);
+            var (from, _) = MoveWorker.ParseMove(moveCoordinates);
 
             var pieceIdentifier = board.Board.GetPieceIdentifier(from);
 

--- a/ChessVariantsLogic/Rules/RuleSet.cs
+++ b/ChessVariantsLogic/Rules/RuleSet.cs
@@ -59,7 +59,11 @@ public class RuleSet
         var acceptedMoves = new List<Move>();
         foreach (var moveCoordinates in possibleMoves)
         {
-            Move move = new Move(moveCoordinates);
+            var (from, _) = board.ParseMove(moveCoordinates);
+
+            var pieceIdentifier = board.Board.GetPieceIdentifier(from);
+
+            Move move = new Move(moveCoordinates, board.GetPieceClassifier(pieceIdentifier));
             BoardTransition transition = new BoardTransition(board, move);
 
             bool ruleSatisfied = _moveRule.Evaluate(transition);
@@ -85,6 +89,6 @@ public class RuleSet
     /// <returns></returns>
     public bool ApplyWinRule(MoveWorker thisBoard)
     {
-        return _winRule.Evaluate(new BoardTransition(thisBoard, new Move("a1a1")));
+        return _winRule.Evaluate(new BoardTransition(thisBoard, new Move("a1a1", PieceClassifier.WHITE)));
     }
 }


### PR DESCRIPTION
# New Predicates
In this pull request, the following predicates have been added:
- PieceMoved, evaluates if a piece with the given identifier was moved during the board transition.
- LastMoveClassifier, evaluates if the piece that performed the last move has the given piece classifier.
- FirstMove, evaluates if this is the first move of the game, i.e. the movelog is empty.
# Other Additions
This pull request also includes the following additions:
- Public method GetPieceClassifier in MoveWorker.
- New boolean variable canBeCaptured in the Piece class. Needed for the duck piece since it cannot be captured. If left as true for shared pieces, both players can capture it.
- New duck piece obviously.
- Actual implementation of duck chess in game factory and new set of pieces in Piece class.
- Tests for new predicates
# Changes
The following changes have been made:
- The Move class now includes the classifier of the piece performing the move (White, Black, Shared).
- The movelog in MoveWorker is now a List of Move instead of a list of string. This is to include more information in the movelog such as what the classifier of the piece that performed the move was.
- ParseMove method in MoveWorker is now static.
- Move method in MoveWorker no longer automatically adds a new move to the movelog, this is instead done in the Perform method of Move.
- pieceBelongsToPlayer in MoveWorker now takes into account shared pieces.
- CanTake method in MoveWorker now takes the previously mentioned canBeCaptured variable into account.