### PR TITLE
Refactor of changes suggested in PR#11

### DIFF
--- a/ChessVariantsLogic.Tests/ChessboardTests.cs
+++ b/ChessVariantsLogic.Tests/ChessboardTests.cs
@@ -113,7 +113,7 @@ public class ChessboardTests : IDisposable
     /// Tests that a piece can not be moved to a square occupied by a piece of the same color.
     /// </summary>
     [Fact]
-    public void CannotMovePieceToOccupiedSquare()
+    public void MovePieceToOccupiedSquare()
     {
         this.moveWorker.Move("h1h2");
         this.moveWorker.Move("b8d7");
@@ -126,7 +126,7 @@ public class ChessboardTests : IDisposable
     /// Tests that an unnoccupied square can not be moved.
     /// </summary>
     [Fact]
-    public void TestMoveUnnoccupiedSquare()
+    public void MoveUnnoccupiedSquare()
     {
         this.moveWorker.Move("e4e5");
         Assert.Equal(0, this.moveWorker.Movelog.Count);
@@ -136,7 +136,7 @@ public class ChessboardTests : IDisposable
     /// Test that a serier of moves can be processed correctly.
     /// </summary>
     [Fact]
-    public void TestSeriesOfMoves()
+    public void PerformSeriesOfMoves()
     {
         this.moveWorker.Move("a2a3");
         this.moveWorker.Move("a3a4");
@@ -234,7 +234,7 @@ public class ChessboardTests : IDisposable
     [InlineData(2, 9)]
     [InlineData(9, 9)]
     [InlineData(10, 7)]
-    public void TestFaultyIndicesByIndex(int row, int col)
+    public void FaultyIndicesByIndex_shouldReturnFalse(int row, int col)
     {
         Assert.False(this.moveWorker.Board.Insert(Constants.BlackBishopIdentifier, row, col));
     }
@@ -242,7 +242,7 @@ public class ChessboardTests : IDisposable
     [Theory]
     [InlineData("j13")]
     [InlineData("n3")]
-    public void TestFaultyIndicesByString(string square)
+    public void FaultyIndicesByString_shouldReturnFalse(string square)
     {
         this.moveWorker.Board = new Chessboard(12);
         Assert.False(this.moveWorker.Board.Insert(Constants.WhiteBishopIdentifier, square));
@@ -333,7 +333,7 @@ public class ChessboardTests : IDisposable
     /// Test that the correct amount of valid moves are found.
     /// </summary>
     [Fact]
-    public void TestThatGetAllValidMovesReturnsCorrectNumberOfMoves()
+    public void GetAllValidMovesReturnsCorrectNumberOfMoves()
     {
         var moves1 = this.moveWorker.GetAllValidMoves(Player.White);
         this.moveWorker.Move("e2e3");
@@ -352,7 +352,7 @@ public class ChessboardTests : IDisposable
     /// Test that the correct amount of valid capture moves are found. 
     /// </summary>
     [Fact]
-    public void TestThatGetAllCapturePatternMovesReturnsCorrectNumberOfMoves()
+    public void GetAllCapturePatternMovesReturnsCorrectNumberOfMoves()
     {
         var moves1 = this.moveWorker.GetAllCapturePatternMoves(Player.White);
         this.moveWorker.Move("e2e3");
@@ -381,7 +381,7 @@ public class ChessboardTests : IDisposable
     }
 
     [Fact]
-    public void MovesLikeRook_CapturesLikeBishop()
+    public void MovesLikeRook_capturesLikeBishop()
     {
         var patterns = new List<IPattern> {
             new RegularPattern(Constants.North, 1, 8),
@@ -414,7 +414,7 @@ public class ChessboardTests : IDisposable
     }
 
     [Fact]
-    public void MoveLikeBishop_CaptureLikeKnight()
+    public void MoveLikeBishop_captureLikeKnight()
     {
         var patterns = new List<IPattern> {
             new RegularPattern(Constants.NorthEast, 1, 8),
@@ -451,7 +451,7 @@ public class ChessboardTests : IDisposable
     }
 
     [Fact]
-    public void TestJumpCapturePattern()
+    public void JumpCapturePattern()
     {
         this.moveWorker.Board = new Chessboard(8);
 

--- a/ChessVariantsLogic.Tests/ChessboardTests.cs
+++ b/ChessVariantsLogic.Tests/ChessboardTests.cs
@@ -10,7 +10,7 @@ namespace ChessVariantsLogic.Tests;
 public class ChessboardTests : IDisposable
 {
     private MoveWorker moveWorker;
-    private const string pieceNotation = "CA";
+    private const string customPieceNotation = "CA";
 
     public ChessboardTests()
     {
@@ -282,7 +282,7 @@ public class ChessboardTests : IDisposable
 
         };
         var mp = new MovementPattern(patterns);
-        Piece piece = new Piece(mp, mp, false, PieceClassifier.WHITE, pieceNotation);
+        Piece piece = new Piece(mp, mp, false, PieceClassifier.WHITE, customPieceNotation);
 
         this.moveWorker.InsertOnBoard(piece, "c4");
 
@@ -293,7 +293,7 @@ public class ChessboardTests : IDisposable
         this.moveWorker.Move("b4d2");
         this.moveWorker.Move("d2a5");
 
-        Assert.Equal(pieceNotation, this.moveWorker.Board.GetPieceIdentifier("a5"));
+        Assert.Equal(customPieceNotation, this.moveWorker.Board.GetPieceIdentifier("a5"));
 
         // Invalid moves
         this.moveWorker.Move("a5b5");
@@ -316,7 +316,7 @@ public class ChessboardTests : IDisposable
             new RegularPattern(Constants.West,  1, 8),
         };
         var mp = new MovementPattern(patterns);
-        Piece piece1 = new Piece(mp, mp, false, PieceClassifier.WHITE, 1, pieceNotation);
+        Piece piece1 = new Piece(mp, mp, false, PieceClassifier.WHITE, 1, customPieceNotation);
         var piece2 = Piece.BlackPawn();
 
         this.moveWorker.InsertOnBoard(piece1, "h4");
@@ -325,7 +325,7 @@ public class ChessboardTests : IDisposable
         this.moveWorker.Move("h4h7"); // Invalid move
         this.moveWorker.Move("h4c5"); // Valid move
 
-        Assert.Equal(pieceNotation, this.moveWorker.Board.GetPieceIdentifier("c5"));
+        Assert.Equal(customPieceNotation, this.moveWorker.Board.GetPieceIdentifier("c5"));
         
     }
 
@@ -399,7 +399,7 @@ public class ChessboardTests : IDisposable
 
         var mp = new MovementPattern(patterns);
         var cp = new MovementPattern(capturePatterns);
-        Piece piece = new Piece(mp, cp, false, PieceClassifier.WHITE, pieceNotation);
+        Piece piece = new Piece(mp, cp, false, PieceClassifier.WHITE, customPieceNotation);
 
         this.moveWorker.InsertOnBoard(piece, "h1");
         this.moveWorker.Move("h2h3");
@@ -409,7 +409,7 @@ public class ChessboardTests : IDisposable
         this.moveWorker.Move("h3e6"); // Invalid move
         this.moveWorker.Move("h3d7"); // Valid move
 
-        Assert.Equal(pieceNotation, this.moveWorker.Board.GetPieceIdentifier("d7"));
+        Assert.Equal(customPieceNotation, this.moveWorker.Board.GetPieceIdentifier("d7"));
 
     }
 
@@ -436,7 +436,7 @@ public class ChessboardTests : IDisposable
 
         var mp = new MovementPattern(patterns);
         var cp = new MovementPattern(capturePattern);
-        Piece piece = new Piece(mp, cp, false, PieceClassifier.WHITE, pieceNotation);
+        Piece piece = new Piece(mp, cp, false, PieceClassifier.WHITE, customPieceNotation);
 
         this.moveWorker.InsertOnBoard(piece, "h1");
         
@@ -446,7 +446,7 @@ public class ChessboardTests : IDisposable
         this.moveWorker.Move("h1c6"); // Valid move
         this.moveWorker.Move("c6d8"); // Valid move
 
-        Assert.Equal(pieceNotation, this.moveWorker.Board.GetPieceIdentifier("d8"));
+        Assert.Equal(customPieceNotation, this.moveWorker.Board.GetPieceIdentifier("d8"));
 
     }
 
@@ -475,7 +475,7 @@ public class ChessboardTests : IDisposable
         
         var mp = new MovementPattern(patterns);
         var cp = new  MovementPattern(capturePatterns);
-        Piece piece1 = new Piece(mp, cp, false, PieceClassifier.WHITE , pieceNotation);
+        Piece piece1 = new Piece(mp, cp, false, PieceClassifier.WHITE , customPieceNotation);
         Piece piece2 = Piece.BlackPawn();
         
         this.moveWorker.InsertOnBoard(piece1, "d4");
@@ -483,6 +483,6 @@ public class ChessboardTests : IDisposable
 
         this.moveWorker.Move("d4e7");
 
-        Assert.Equal(pieceNotation, this.moveWorker.Board.GetPieceIdentifier("e7"));
+        Assert.Equal(customPieceNotation, this.moveWorker.Board.GetPieceIdentifier("e7"));
     }
 }

--- a/ChessVariantsLogic.Tests/ChessboardTests.cs
+++ b/ChessVariantsLogic.Tests/ChessboardTests.cs
@@ -5,7 +5,7 @@ using Xunit;
 namespace ChessVariantsLogic.Tests;
 
 /// <summary>
-/// This class contains unit tests on Chessboard.cs and ChessDriver.cs.
+/// This class contains unit tests on Chessboard and MoveWorker.
 /// </summary>
 public class ChessboardTests : IDisposable
 {
@@ -53,7 +53,7 @@ public class ChessboardTests : IDisposable
     /// Tests that the standard chessboard is set up correctly.
     /// </summary>
     [Fact]
-    public void Test_Standard_Chessboard()
+    public void StandardChessboardIsSetUpCorrectly()
     {
         Assert.Equal(Constants.WhiteKingIdentifier,         this.board.GetPieceIdentifier("e1"));
         Assert.Equal(Constants.BlackQueenIdentifier,        this.board.GetPieceIdentifier("d8"));
@@ -69,11 +69,11 @@ public class ChessboardTests : IDisposable
     {
         Assert.Equal(Constants.WhitePawnIdentifier,         this.moveWorker.Board.GetPieceIdentifier("g2"));
         Assert.Equal(Constants.UnoccupiedSquareIdentifier,  this.moveWorker.Board.GetPieceIdentifier("g3"));
-        Assert.Equal(GameEvent.MoveSucceeded,               this.moveWorker.Move("g2g3"));
+        this.moveWorker.Move("g2g3");
         Assert.Equal(Constants.UnoccupiedSquareIdentifier,  this.moveWorker.Board.GetPieceIdentifier("g2"));
         Assert.Equal(Constants.WhitePawnIdentifier,         this.moveWorker.Board.GetPieceIdentifier("g3"));
         
-        Assert.Equal(GameEvent.InvalidMove,                 this.moveWorker.Move("h2h9"));
+        this.moveWorker.Move("h2h9");
         Assert.Equal(Constants.WhitePawnIdentifier,         this.moveWorker.Board.GetPieceIdentifier("h2"));
 
     }
@@ -86,14 +86,13 @@ public class ChessboardTests : IDisposable
     {
         this.moveWorker.Board = new Chessboard(4,10);
         
-        moveWorker.InsertOnBoard(Piece.Rook(PieceClassifier.BLACK), "b2");
+        this.moveWorker.InsertOnBoard(Piece.Rook(PieceClassifier.BLACK), "b2");
+        this.moveWorker.Move("b2i2");
 
-        Assert.Equal(Constants.BlackRookIdentifier,         this.moveWorker.Board.GetPieceIdentifier("b2"));
-        Assert.Equal(GameEvent.MoveSucceeded,               this.moveWorker.Move("b2i2"));
         Assert.Equal(Constants.UnoccupiedSquareIdentifier,  this.moveWorker.Board.GetPieceIdentifier("b2"));
         Assert.Equal(Constants.BlackRookIdentifier,         this.moveWorker.Board.GetPieceIdentifier("i2"));
 
-        Assert.Equal(GameEvent.MoveSucceeded,               this.moveWorker.Move("i2i4"));
+        this.moveWorker.Move("i2i4");
         Assert.Equal(Constants.UnoccupiedSquareIdentifier,  this.moveWorker.Board.GetPieceIdentifier("i2"));
         Assert.Equal(Constants.BlackRookIdentifier,         this.moveWorker.Board.GetPieceIdentifier("i4"));
 
@@ -103,7 +102,7 @@ public class ChessboardTests : IDisposable
     /// Tests that a piece that is not allowed to jump, can not jump over other pieces.
     /// </summary>
     [Fact]
-    public void PieceWithoutJumpPatternCannotJumpOverOtherPieces()
+    public void PieceWithoutJumpPattern_CannotJumpOverOtherPieces()
     {
         Assert.Equal(GameEvent.InvalidMove, this.moveWorker.Move("h1h4"));
         Assert.Equal(GameEvent.InvalidMove, this.moveWorker.Move("c8e6"));

--- a/ChessVariantsLogic.Tests/ChessboardTests.cs
+++ b/ChessVariantsLogic.Tests/ChessboardTests.cs
@@ -7,9 +7,9 @@ namespace ChessVariantsLogic.Tests;
 /// <summary>
 /// This class contains unit tests on Chessboard.cs and ChessDriver.cs.
 /// </summary>
-public class ChessboardTests //: IDisposable
+public class ChessboardTests : IDisposable
 {
-    /*private MoveWorker moveWorker;
+    private MoveWorker moveWorker;
     private Chessboard board;
 
     public ChessboardTests()
@@ -20,11 +20,10 @@ public class ChessboardTests //: IDisposable
 
     public void Dispose()
     {
-        this.board = new Chessboard(8);
-        this.moveWorker = new MoveWorker(this.board);
+        this.board = Chessboard.StandardChessboard();
+        this.moveWorker = new MoveWorker(this.board, Piece.AllStandardPieces());
         GC.SuppressFinalize(this);
     }
-    */
 
     /// <summary>
     /// Tests that the FEN representation of the board is of the correct format.
@@ -56,29 +55,26 @@ public class ChessboardTests //: IDisposable
     [Fact]
     public void Test_Standard_Chessboard()
     {
-        var board = Chessboard.StandardChessboard();
-        Assert.Equal(Constants.WhiteKingIdentifier,         board.GetPieceIdentifier("e1"));
-        Assert.Equal(Constants.BlackQueenIdentifier,        board.GetPieceIdentifier("d8"));
-        Assert.Equal(Constants.UnoccupiedSquareIdentifier,  board.GetPieceIdentifier("e4"));
-        Assert.Equal(Constants.BlackRookIdentifier,         board.GetPieceIdentifier("a8"));
+        Assert.Equal(Constants.WhiteKingIdentifier,         this.board.GetPieceIdentifier("e1"));
+        Assert.Equal(Constants.BlackQueenIdentifier,        this.board.GetPieceIdentifier("d8"));
+        Assert.Equal(Constants.UnoccupiedSquareIdentifier,  this.board.GetPieceIdentifier("e4"));
+        Assert.Equal(Constants.BlackRookIdentifier,         this.board.GetPieceIdentifier("a8"));
     }
 
     /// <summary>
     /// Tests that moving a piece updates the board correctly.
     /// </summary>
     [Fact]
-    public void Test_Move_Pawn()
+    public void PawnMovesCorrectly()
     {
-        var moveWorker = new MoveWorker(Chessboard.StandardChessboard(), Piece.AllStandardPieces());
-
-        Assert.Equal(Constants.WhitePawnIdentifier,         moveWorker.Board.GetPieceIdentifier("g2"));
-        Assert.Equal(Constants.UnoccupiedSquareIdentifier,  moveWorker.Board.GetPieceIdentifier("g3"));
-        Assert.Equal(GameEvent.MoveSucceeded, moveWorker.Move("g2g3"));
-        Assert.Equal(Constants.UnoccupiedSquareIdentifier,  moveWorker.Board.GetPieceIdentifier("g2"));
-        Assert.Equal(Constants.WhitePawnIdentifier,         moveWorker.Board.GetPieceIdentifier("g3"));
+        Assert.Equal(Constants.WhitePawnIdentifier,         this.moveWorker.Board.GetPieceIdentifier("g2"));
+        Assert.Equal(Constants.UnoccupiedSquareIdentifier,  this.moveWorker.Board.GetPieceIdentifier("g3"));
+        Assert.Equal(GameEvent.MoveSucceeded,               this.moveWorker.Move("g2g3"));
+        Assert.Equal(Constants.UnoccupiedSquareIdentifier,  this.moveWorker.Board.GetPieceIdentifier("g2"));
+        Assert.Equal(Constants.WhitePawnIdentifier,         this.moveWorker.Board.GetPieceIdentifier("g3"));
         
-        Assert.Equal(GameEvent.InvalidMove, moveWorker.Move("h2h9"));
-        Assert.Equal(Constants.WhitePawnIdentifier, moveWorker.Board.GetPieceIdentifier("h2"));
+        Assert.Equal(GameEvent.InvalidMove,                 this.moveWorker.Move("h2h9"));
+        Assert.Equal(Constants.WhitePawnIdentifier,         this.moveWorker.Board.GetPieceIdentifier("h2"));
 
     }
 
@@ -86,205 +82,181 @@ public class ChessboardTests //: IDisposable
     /// Test that a rook can move correcly on non-standard chessboard.
     /// </summary>
     [Fact]
-    public void Test_Rook_Rectangular_Board()
+    public void RookMovesCorrectlyOnRectangularBoard()
     {
-        var moveWorker = new MoveWorker(new Chessboard(4,10));
+        this.moveWorker.Board = new Chessboard(4,10);
         
-        Assert.True(moveWorker.InsertOnBoard(Piece.Rook(PieceClassifier.BLACK), "b2"));
+        moveWorker.InsertOnBoard(Piece.Rook(PieceClassifier.BLACK), "b2");
 
-        Assert.Equal(Constants.BlackRookIdentifier,         moveWorker.Board.GetPieceIdentifier("b2"));
-        Assert.Equal(GameEvent.MoveSucceeded, moveWorker.Move("b2i2"));
-        Assert.Equal(Constants.UnoccupiedSquareIdentifier,  moveWorker.Board.GetPieceIdentifier("b2"));
-        Assert.Equal(Constants.BlackRookIdentifier,         moveWorker.Board.GetPieceIdentifier("i2"));
+        Assert.Equal(Constants.BlackRookIdentifier,         this.moveWorker.Board.GetPieceIdentifier("b2"));
+        Assert.Equal(GameEvent.MoveSucceeded,               this.moveWorker.Move("b2i2"));
+        Assert.Equal(Constants.UnoccupiedSquareIdentifier,  this.moveWorker.Board.GetPieceIdentifier("b2"));
+        Assert.Equal(Constants.BlackRookIdentifier,         this.moveWorker.Board.GetPieceIdentifier("i2"));
 
-        Assert.Equal(GameEvent.MoveSucceeded, moveWorker.Move("i2i4"));
-        Assert.Equal(Constants.UnoccupiedSquareIdentifier,  moveWorker.Board.GetPieceIdentifier("i2"));
-        Assert.Equal(Constants.BlackRookIdentifier,         moveWorker.Board.GetPieceIdentifier("i4"));
+        Assert.Equal(GameEvent.MoveSucceeded,               this.moveWorker.Move("i2i4"));
+        Assert.Equal(Constants.UnoccupiedSquareIdentifier,  this.moveWorker.Board.GetPieceIdentifier("i2"));
+        Assert.Equal(Constants.BlackRookIdentifier,         this.moveWorker.Board.GetPieceIdentifier("i4"));
 
     }
 
     /// <summary>
-    /// Tests that invalid moves are not processed.
+    /// Tests that a piece that is not allowed to jump, can not jump over other pieces.
     /// </summary>
     [Fact]
-    public void Test_Invalid_Move()
+    public void PieceWithoutJumpPatternCannotJumpOverOtherPieces()
     {
-        var moveWorker = new MoveWorker(Chessboard.StandardChessboard(), Piece.AllStandardPieces());
+        Assert.Equal(GameEvent.InvalidMove, this.moveWorker.Move("h1h4"));
+        Assert.Equal(GameEvent.InvalidMove, this.moveWorker.Move("c8e6"));
+    }
 
-        Assert.Equal(Constants.WhiteRookIdentifier,         moveWorker.Board.GetPieceIdentifier("h1"));
-        Assert.Equal(Constants.WhitePawnIdentifier,         moveWorker.Board.GetPieceIdentifier("h2"));
-        Assert.Equal(Constants.UnoccupiedSquareIdentifier,  moveWorker.Board.GetPieceIdentifier("h4"));
-        Assert.Equal(GameEvent.InvalidMove, moveWorker.Move("h1h4"));
-        Assert.Equal(Constants.WhiteRookIdentifier,         moveWorker.Board.GetPieceIdentifier("h1"));
-        Assert.Equal(Constants.UnoccupiedSquareIdentifier,  moveWorker.Board.GetPieceIdentifier("h4"));
-        
-        Assert.Equal(Constants.BlackKnightIdentifier,       moveWorker.Board.GetPieceIdentifier("b8"));
-        Assert.Equal(Constants.BlackPawnIdentifier,         moveWorker.Board.GetPieceIdentifier("d7"));
-        Assert.Equal(GameEvent.InvalidMove, moveWorker.Move("b8d7"));
-        Assert.Equal(Constants.BlackKnightIdentifier,       moveWorker.Board.GetPieceIdentifier("b8"));
-        Assert.Equal(Constants.BlackPawnIdentifier,         moveWorker.Board.GetPieceIdentifier("d7"));
+    /// <summary>
+    /// Tests that a piece can not be moved to a square occupied by a piece of the same color.
+    /// </summary>
+    [Fact]
+    public void CannotMovePieceToOccupiedSquare()
+    {
+        Assert.Equal(GameEvent.InvalidMove, this.moveWorker.Move("b8d7"));
+        Assert.Equal(GameEvent.InvalidMove, this.moveWorker.Move("h1h2"));
+    }
 
-        Assert.Equal(Constants.UnoccupiedSquareIdentifier,  moveWorker.Board.GetPieceIdentifier("e4"));
-        Assert.Equal(Constants.UnoccupiedSquareIdentifier,  moveWorker.Board.GetPieceIdentifier("e5"));
-        Assert.Equal(GameEvent.InvalidMove, moveWorker.Move("e4e5"));
-        Assert.Equal(Constants.UnoccupiedSquareIdentifier,  moveWorker.Board.GetPieceIdentifier("e4"));
-        Assert.Equal(Constants.UnoccupiedSquareIdentifier,  moveWorker.Board.GetPieceIdentifier("e5"));
-
+    /// <summary>
+    /// Tests that an unnoccupied square can not be moved.
+    /// </summary>
+    [Fact]
+    public void TestMoveUnnoccupiedSquare()
+    {
+        Assert.Equal(GameEvent.InvalidMove, this.moveWorker.Move("e4e5"));
     }
 
     /// <summary>
     /// Test that a serier of moves can be processed correctly.
     /// </summary>
     [Fact]
-    public void Test_Move_Serie()
+    public void TestSeriesOfMoves()
     {
-        var moveWorker = new MoveWorker(Chessboard.StandardChessboard(), Piece.AllStandardPieces());
+        this.moveWorker.Move("a2a3");
+        this.moveWorker.Move("a3a4");
+        this.moveWorker.Move("a4a5");
 
-        Assert.Equal(Constants.WhitePawnIdentifier,         moveWorker.Board.GetPieceIdentifier("a2"));
-        Assert.Equal(Constants.UnoccupiedSquareIdentifier,  moveWorker.Board.GetPieceIdentifier("a3"));
-        Assert.Equal(GameEvent.MoveSucceeded, moveWorker.Move("a2a3"));
-        Assert.Equal(GameEvent.MoveSucceeded, moveWorker.Move("a3a4"));
-        Assert.Equal(Constants.UnoccupiedSquareIdentifier,  moveWorker.Board.GetPieceIdentifier("a2"));
-        Assert.Equal(Constants.UnoccupiedSquareIdentifier,  moveWorker.Board.GetPieceIdentifier("a3"));
-        Assert.Equal(Constants.WhitePawnIdentifier,         moveWorker.Board.GetPieceIdentifier("a4"));
+        Assert.Equal(Constants.UnoccupiedSquareIdentifier,  this.moveWorker.Board.GetPieceIdentifier("a2"));
+        Assert.Equal(Constants.UnoccupiedSquareIdentifier,  this.moveWorker.Board.GetPieceIdentifier("a3"));
+        Assert.Equal(Constants.UnoccupiedSquareIdentifier,  this.moveWorker.Board.GetPieceIdentifier("a4"));
+        Assert.Equal(Constants.WhitePawnIdentifier,         this.moveWorker.Board.GetPieceIdentifier("a5"));
     }
 
     /// <summary>
     /// Tests that a knight can jump over pieces and move correctly.
     /// </summary>
     [Fact]
-    public void Test_Move_Knight()
+    public void KnightCanMoveProperly()
     {
-        var moveWorker = new MoveWorker(Chessboard.StandardChessboard(), Piece.AllStandardPieces());
-
-        Assert.Equal(Constants.WhiteKnightIdentifier,       moveWorker.Board.GetPieceIdentifier("g1"));
-        Assert.Equal(Constants.UnoccupiedSquareIdentifier,  moveWorker.Board.GetPieceIdentifier("h3"));
         Assert.Equal(GameEvent.MoveSucceeded, moveWorker.Move("g1h3"));
-        Assert.Equal(Constants.UnoccupiedSquareIdentifier,  moveWorker.Board.GetPieceIdentifier("g1"));
-        Assert.Equal(Constants.WhiteKnightIdentifier,       moveWorker.Board.GetPieceIdentifier("h3"));
         Assert.Equal(GameEvent.MoveSucceeded, moveWorker.Move("h3f4"));
     }
       
     /// <summary>
-    /// Test that pices can be captured correctly.
+    /// Test that a knight can capture other pieces correctly.
     /// </summary>
     [Fact]
-     public void Test_Take()
+     public void KnightCanCaptureCorrectly()
      {
-        var moveWorker = new MoveWorker(Chessboard.StandardChessboard(), Piece.AllStandardPieces());
+        this.moveWorker.Move("g1h3");
+        this.moveWorker.Move("h3g5");
+        this.moveWorker.Move("g5h7");
 
-        Assert.Equal(Constants.WhiteKnightIdentifier,       moveWorker.Board.GetPieceIdentifier("g1"));
-        Assert.Equal(Constants.UnoccupiedSquareIdentifier,  moveWorker.Board.GetPieceIdentifier("h3"));
-        Assert.Equal(GameEvent.MoveSucceeded, moveWorker.Move("g1h3"));
-        Assert.Equal(GameEvent.MoveSucceeded, moveWorker.Move("h3g5"));
-        Assert.Equal(GameEvent.MoveSucceeded, moveWorker.Move("g5h7"));
-        Assert.Equal(Constants.UnoccupiedSquareIdentifier,  moveWorker.Board.GetPieceIdentifier("g5"));
-        Assert.Equal(Constants.WhiteKnightIdentifier,       moveWorker.Board.GetPieceIdentifier("h7"));
+        Assert.Equal(Constants.UnoccupiedSquareIdentifier,  this.moveWorker.Board.GetPieceIdentifier("g5"));
+        Assert.Equal(Constants.WhiteKnightIdentifier,       this.moveWorker.Board.GetPieceIdentifier("h7"));
      }
 
     /// <summary>
     /// Tests that a bishop, a piece that can not jump, can capture opponents pieces.
     /// </summary>
      [Fact]
-     public void PieceNotJumpCanCapture_shouldReturnTrue()
+     public void NonJumpablePieceCanCapture()
      {
-        var moveWorker = new MoveWorker(Chessboard.StandardChessboard(), Piece.AllStandardPieces());
+        this.moveWorker.Move("e2e3");
+        this.moveWorker.Move("f1a6");
+        this.moveWorker.Move("a6b7");
 
-        Assert.Equal(Constants.BlackPawnIdentifier, moveWorker.Board.GetPieceIdentifier("b7"));
-
-        Assert.Equal(GameEvent.MoveSucceeded, moveWorker.Move("e2e3"));
-        Assert.Equal(GameEvent.MoveSucceeded, moveWorker.Move("f1a6"));
-        Assert.Equal(GameEvent.MoveSucceeded, moveWorker.Move("a6b7"));
-
-        Assert.Equal(Constants.UnoccupiedSquareIdentifier,  moveWorker.Board.GetPieceIdentifier("a6"));
-        Assert.Equal(Constants.WhiteBishopIdentifier,       moveWorker.Board.GetPieceIdentifier("b7"));
-     }
-
-    [Fact]
-     public void PawnCanCaptureDiagonally_shouldReturnTrue()
-     {
-        var moveWorker = new MoveWorker(Chessboard.StandardChessboard(), Piece.AllStandardPieces());
-
-        Assert.Equal(Constants.BlackPawnIdentifier, moveWorker.Board.GetPieceIdentifier("d7"));
-
-        Assert.Equal(GameEvent.MoveSucceeded, moveWorker.Move("e2e3"));
-        Assert.Equal(GameEvent.MoveSucceeded, moveWorker.Move("e3e4"));
-        Assert.Equal(GameEvent.MoveSucceeded, moveWorker.Move("e4e5"));
-        Assert.Equal(GameEvent.MoveSucceeded, moveWorker.Move("e5e6"));
-        Assert.Equal(GameEvent.MoveSucceeded, moveWorker.Move("e6d7"));
-
-        Assert.Equal(Constants.UnoccupiedSquareIdentifier,  moveWorker.Board.GetPieceIdentifier("e6"));
-        Assert.Equal(Constants.WhitePawnIdentifier,         moveWorker.Board.GetPieceIdentifier("d7"));
-     }
-     
-     /// <summary>
-     /// Test that the bishop can move correctly diagonally.
-     /// </summary>
-     [Fact]
-     public void Test_Bishop()
-     {
-        var moveWorker = new MoveWorker(Chessboard.StandardChessboard(), Piece.AllStandardPieces());
-
-        Assert.Equal(GameEvent.InvalidMove, moveWorker.Move("f1c4"));
-        Assert.Equal(GameEvent.MoveSucceeded, moveWorker.Move("e2e3"));
-        Assert.Equal(GameEvent.MoveSucceeded, moveWorker.Move("f1c4"));
-        Assert.Equal(Constants.UnoccupiedSquareIdentifier,  moveWorker.Board.GetPieceIdentifier("f1"));
-        Assert.Equal(Constants.WhiteBishopIdentifier,       moveWorker.Board.GetPieceIdentifier("c4"));
-     }
-
-    
-     [Fact]
-     public void Test_Move_King()
-     {
-        var moveWorker = new MoveWorker(Chessboard.StandardChessboard(), Piece.AllStandardPieces());
-
-        Assert.Equal(Constants.WhiteKingIdentifier,  moveWorker.Board.GetPieceIdentifier("e1"));
-        Assert.Equal(GameEvent.MoveSucceeded, moveWorker.Move("e2e3"));
-        Assert.Equal(GameEvent.MoveSucceeded, moveWorker.Move("e1e2"));
-        Assert.Equal(GameEvent.InvalidMove, moveWorker.Move("e2e3"));
-        Assert.Equal(Constants.UnoccupiedSquareIdentifier,  moveWorker.Board.GetPieceIdentifier("e1"));
-        Assert.Equal(Constants.WhiteKingIdentifier,  moveWorker.Board.GetPieceIdentifier("e2"));
-        Assert.Equal(Constants.WhitePawnIdentifier,  moveWorker.Board.GetPieceIdentifier("e3"));
-        Assert.Equal(GameEvent.MoveSucceeded, moveWorker.Move("e2f3"));
-
+        Assert.Equal(Constants.UnoccupiedSquareIdentifier,  this.moveWorker.Board.GetPieceIdentifier("a6"));
+        Assert.Equal(Constants.WhiteBishopIdentifier,       this.moveWorker.Board.GetPieceIdentifier("b7"));
      }
 
     /// <summary>
-    /// Tests that pieces can not be inserted into squares outside of the chessboard.
+    /// Tests that a pawn can capture diagonally.
     /// </summary>
     [Fact]
-    public void Test_Faulty_Indices()
+     public void PawnCanCaptureDiagonally()
+     {
+        this.moveWorker.Move("e2e3");
+        this.moveWorker.Move("e3e4");
+        this.moveWorker.Move("e4e5");
+        this.moveWorker.Move("e5e6");
+        this.moveWorker.Move("e6d7");
+
+        Assert.Equal(Constants.UnoccupiedSquareIdentifier,  this.moveWorker.Board.GetPieceIdentifier("e6"));
+        Assert.Equal(Constants.WhitePawnIdentifier,         this.moveWorker.Board.GetPieceIdentifier("d7"));
+     }
+     
+    /// <summary>
+    /// Test that the bishop can move correctly diagonally.
+    /// </summary>
+    [Fact]
+    public void BishopCanMoveDiagonally()
     {
-        var board = Chessboard.StandardChessboard();
-        Assert.False(board.Insert(Constants.BlackBishopIdentifier, 2, 9));
-        Assert.False(board.Insert(Constants.BlackBishopIdentifier, 9, 9));
-        Assert.False(board.Insert(Constants.BlackBishopIdentifier, 10, 7));
-        Assert.True(board.Insert(Constants.BlackBishopIdentifier, "h8"));
+       this.moveWorker.Move("e2e3");
+       this.moveWorker.Move("f1c4");
+        
+       Assert.Equal(Constants.UnoccupiedSquareIdentifier,  this.moveWorker.Board.GetPieceIdentifier("f1"));
+       Assert.Equal(Constants.WhiteBishopIdentifier,       this.moveWorker.Board.GetPieceIdentifier("c4"));
+    }
 
-        board = new Chessboard(12, 12);
-        Assert.True(board.Insert(Constants.WhiteBishopIdentifier, "j3"));
-        Assert.False(board.Insert(Constants.WhiteBishopIdentifier, "n3"));
-        Assert.False(board.Insert(Constants.WhiteBishopIdentifier, new Tuple<int, int>(3, 14)));
+    /// <summary>
+    /// Test that the king can move correctly.
+    /// </summary>
+    [Fact]
+    public void KingCanMoveCorrectly()
+    {
+       this.moveWorker.Move("e2e3");
+       this.moveWorker.Move("e1e2");
+       this.moveWorker.Move("e2f3");
 
+       Assert.Equal(Constants.UnoccupiedSquareIdentifier,  this.moveWorker.Board.GetPieceIdentifier("e1"));
+       Assert.Equal(Constants.WhiteKingIdentifier,         this.moveWorker.Board.GetPieceIdentifier("f3"));
+    }
+
+    [Theory]
+    [InlineData(2, 9)]
+    [InlineData(9, 9)]
+    [InlineData(10, 7)]
+    public void TestFaultyIndicesByIndex(int row, int col)
+    {
+        Assert.False(board.Insert(Constants.BlackBishopIdentifier, row, col));
+    }
+
+    [Theory]
+    [InlineData("j13")]
+    [InlineData("n3")]
+    public void TestFaultyIndicesByString(string square)
+    {
+        this.moveWorker.Board = new Chessboard(12);
+        Assert.False(board.Insert(Constants.WhiteBishopIdentifier, square));
     }
 
     /// <summary>
     /// Test that the queen can move both straight and diagnoally.
     /// </summary>
     [Fact]
-    public void Test_Queen()
+    public void QueenCanMoveCorrectly()
     {
-        var moveWorker = new MoveWorker(new Chessboard(6,5));
+        this.moveWorker.Board = new Chessboard(6,5);
         
-        Assert.True(moveWorker.InsertOnBoard(Piece.Queen(PieceClassifier.WHITE), "c4"));
-        Assert.Equal(Constants.UnoccupiedSquareIdentifier, moveWorker.Board.GetPieceIdentifier("a6"));
-        Assert.Equal(GameEvent.MoveSucceeded, moveWorker.Move("c4a6"));
-        Assert.Equal(Constants.UnoccupiedSquareIdentifier, moveWorker.Board.GetPieceIdentifier("c4"));
-        Assert.Equal(Constants.WhiteQueenIdentifier, moveWorker.Board.GetPieceIdentifier("a6"));
+        this.moveWorker.InsertOnBoard(Piece.Queen(PieceClassifier.WHITE), "c4");
+        this.moveWorker.Move("c4a6");
+        this.moveWorker.Move("a6a1");
 
-        Assert.Equal(GameEvent.MoveSucceeded, moveWorker.Move("a6a1"));
-        Assert.Equal(Constants.UnoccupiedSquareIdentifier, moveWorker.Board.GetPieceIdentifier("a6"));
-        Assert.Equal(Constants.WhiteQueenIdentifier, moveWorker.Board.GetPieceIdentifier("a1"));
+        Assert.Equal(Constants.UnoccupiedSquareIdentifier,  this.moveWorker.Board.GetPieceIdentifier("c4"));
+        Assert.Equal(Constants.WhiteQueenIdentifier,        this.moveWorker.Board.GetPieceIdentifier("a1"));
 
     }
 
@@ -292,9 +264,9 @@ public class ChessboardTests //: IDisposable
     /// Test that a custom piece with a novel movement pattern moves correctly.
     /// </summary>
     [Fact]
-    public void Test_Custom_Piece()
+    public void PieceWithNovelMovementCanMoveCorrectly()
     {
-        var moveWorker = new MoveWorker(new Chessboard(8));
+        moveWorker.Board = new Chessboard(8);
 
         var patterns = new List<IPattern> {
             new RegularPattern(Constants.North,     1, 3),
@@ -305,45 +277,53 @@ public class ChessboardTests //: IDisposable
 
         };
         var mp = new MovementPattern(patterns);
-        Piece piece = new Piece(mp, mp, false, PieceClassifier.WHITE, "C");
+        string pieceNotation = "CA";
+        Piece piece = new Piece(mp, mp, false, PieceClassifier.WHITE, pieceNotation);
 
-        Assert.True(moveWorker.InsertOnBoard(piece, "c4"));
-        Assert.Equal(GameEvent.MoveSucceeded, moveWorker.Move("c4c5"));
-        Assert.Equal(GameEvent.MoveSucceeded, moveWorker.Move("c5d6"));
-        Assert.Equal(GameEvent.MoveSucceeded, moveWorker.Move("d6b4"));
-        Assert.Equal(GameEvent.MoveSucceeded, moveWorker.Move("b4d2"));
-        Assert.Equal(GameEvent.MoveSucceeded, moveWorker.Move("d2a5"));
-        Assert.Equal(GameEvent.InvalidMove, moveWorker.Move("a5b5"));
-        Assert.Equal(GameEvent.InvalidMove, moveWorker.Move("a5b4"));
-        Assert.Equal(GameEvent.InvalidMove, moveWorker.Move("a5a4"));
+        this.moveWorker.InsertOnBoard(piece, "c4");
 
-        Assert.True(moveWorker.InsertOnBoard(piece, "h3"));
-        Assert.Equal(GameEvent.InvalidMove, moveWorker.Move("h3c8"));
-        Assert.Equal(GameEvent.MoveSucceeded, moveWorker.Move("h3d7"));
+        // Valid moves
+        this.moveWorker.Move("c4c5");
+        this.moveWorker.Move("c5d6");
+        this.moveWorker.Move("d6b4");
+        this.moveWorker.Move("b4d2");
+        this.moveWorker.Move("d2a5");
+
+        var expected = pieceNotation;
+        var actual = this.moveWorker.Board.GetPieceIdentifier("a5");
+        Assert.Equal(expected, actual);
+
+        // Invalid moves
+        this.moveWorker.Move("a5b5");
+        this.moveWorker.Move("a5b4");
+        this.moveWorker.Move("a5a4");
+
+        expected = Constants.UnoccupiedSquareIdentifier;
+        actual = this.moveWorker.Board.GetPieceIdentifier("a4");
+        Assert.Equal(expected, actual);
     }
 
     /// <summary>
     /// Tests that a custom piece can repeat its movement pattern, if allowed.
     /// </summary>
     [Fact]
-    public void Test_Custom_Piece_Repeat()
+    public void PieceWithRepeatingMovementPatternCanMoveCorrectly()
     {
-        var moveWorker = new MoveWorker(new Chessboard(8));
+        this.moveWorker.Board = new Chessboard(8);
 
         var patterns = new List<IPattern> {
             new RegularPattern(Constants.North, 1, 8),
             new RegularPattern(Constants.West,  1, 8),
         };
         var mp = new MovementPattern(patterns);
-        Piece piece = new Piece(mp, mp, false, PieceClassifier.WHITE, 1, "C");
-
-        Assert.True(moveWorker.InsertOnBoard(piece, "h4"));
-       
-
+        Piece piece1 = new Piece(mp, mp, false, PieceClassifier.WHITE, 1, "CA");
         var piece2 = Piece.BlackPawn();
-        Assert.True(moveWorker.InsertOnBoard(piece2, "h6"));
-        Assert.Equal(GameEvent.InvalidMove, moveWorker.Move("h4h7"));
-        Assert.Equal(GameEvent.MoveSucceeded, moveWorker.Move("h4c5"));
+
+        this.moveWorker.InsertOnBoard(piece1, "h4");
+        this.moveWorker.InsertOnBoard(piece2, "h6");
+
+        Assert.Equal(GameEvent.InvalidMove,     this.moveWorker.Move("h4h7"));
+        Assert.Equal(GameEvent.MoveSucceeded,   this.moveWorker.Move("h4c5"));
         
     }
 
@@ -351,56 +331,61 @@ public class ChessboardTests //: IDisposable
     /// Test that the correct amount of valid moves are found.
     /// </summary>
     [Fact]
-    public void Test_GetAllValidMoves()
+    public void TestThatGetAllValidMovesReturnsCorrectNumberOfMoves()
     {
-        var moveWorker = new MoveWorker(Chessboard.StandardChessboard(), Piece.AllStandardPieces());
+        var moves1 = this.moveWorker.GetAllValidMoves(Player.White);
+        this.moveWorker.Move("e2e3");
+        var moves2 = this.moveWorker.GetAllValidMoves(Player.White);
 
-        var moves = moveWorker.GetAllValidMoves(Player.White);
-        Assert.Equal(12, moves.Count);
-        Assert.Equal(GameEvent.MoveSucceeded, moveWorker.Move("e2e3"));
-        var moves2 = moveWorker.GetAllValidMoves(Player.White);
+        this.moveWorker.Board = new Chessboard(8);
+        this.moveWorker.InsertOnBoard(Piece.Queen(PieceClassifier.WHITE), "e4");
+        var movesQueen = this.moveWorker.GetAllValidMoves(Player.White);
+
+        Assert.Equal(12, moves1.Count);
         Assert.Equal(23, moves2.Count);
-
-        moveWorker.Board = new Chessboard(8);
-        Assert.True(moveWorker.InsertOnBoard(Piece.Queen(PieceClassifier.WHITE), "e4"));
-        var movesQueen = moveWorker.GetAllValidMoves(Player.White);
         Assert.Equal(27, movesQueen.Count);
     }
 
     /// <summary>
-    /// Test that the correct amount of valid capture movesare found. 
+    /// Test that the correct amount of valid capture moves are found. 
     /// </summary>
     [Fact]
-    public void Test_GetAllCaptureMoves()
+    public void TestThatGetAllCapturePatternMovesReturnsCorrectNumberOfMoves()
     {
-        var moveWorker = new MoveWorker(Chessboard.StandardChessboard(), Piece.AllStandardPieces());
+        var moves1 = this.moveWorker.GetAllCapturePatternMoves(Player.White);
+        this.moveWorker.Move("e2e3");
+        var moves2 = this.moveWorker.GetAllCapturePatternMoves(Player.White);
+        
+        this.moveWorker.Board = new Chessboard(8);
 
-        var moves = moveWorker.GetAllCaptureMoves(Player.White);
-        Assert.Equal(18, moves.Count);
-        Assert.Equal(GameEvent.MoveSucceeded, moveWorker.Move("e2e3"));
-        var moves2 = moveWorker.GetAllCaptureMoves(Player.White);
+        this.moveWorker.InsertOnBoard(Piece.Queen(PieceClassifier.WHITE), "e4");
+        var movesQueen = this.moveWorker.GetAllCapturePatternMoves(Player.White);
+
+        Assert.Equal(18, moves1.Count);
         Assert.Equal(27, moves2.Count);
-        
-        Assert.Equal(GameEvent.MoveSucceeded, moveWorker.Move("e7e6"));
-        Assert.Equal(2, moveWorker.Movelog.Count);
-        
-        moveWorker.Board = new Chessboard(8);
-
-        Assert.True(moveWorker.InsertOnBoard(Piece.Queen(PieceClassifier.WHITE), "e4"));
-        var movesQueen = moveWorker.GetAllCaptureMoves(Player.White);
         Assert.Equal(27, movesQueen.Count);
     }
 
     [Fact]
-    public void TestDifferentCapturePattern()
+    public void MoveLogCorrectlySavesAllMoves()
     {
-        var moveWorker = new MoveWorker(Chessboard.StandardChessboard(), Piece.AllStandardPieces());
+        this.moveWorker.Move("h2h3");
+        this.moveWorker.Move("h3h4");
+        this.moveWorker.Move("h1h3");
+        this.moveWorker.Move("h3e3");
+        
+        var expected = new List<string> {"h2h3","h3h4","h1h3","h3e3"};
+        Assert.Equal(expected, this.moveWorker.Movelog);
+    }
 
+    [Fact]
+    public void MovesLikeRook_CapturesLikeBishop()
+    {
         var patterns = new List<IPattern> {
             new RegularPattern(Constants.North, 1, 8),
-            new RegularPattern(Constants.East, 1, 8),
+            new RegularPattern(Constants.East,  1, 8),
             new RegularPattern(Constants.South, 1, 8),
-            new RegularPattern(Constants.West, 1, 8),
+            new RegularPattern(Constants.West,  1, 8),
         };
 
         var capturePatterns = new List<IPattern> {
@@ -412,24 +397,21 @@ public class ChessboardTests //: IDisposable
 
         var mp = new MovementPattern(patterns);
         var cp = new MovementPattern(capturePatterns);
-        Piece piece = new Piece(mp, cp, false, PieceClassifier.WHITE, "C");
+        Piece piece = new Piece(mp, cp, false, PieceClassifier.WHITE, "CA");
 
-        Assert.True(moveWorker.InsertOnBoard(piece, "h1"));
+        this.moveWorker.InsertOnBoard(piece, "h1");
+        this.moveWorker.Move("h2h3");
+        this.moveWorker.Move("h3h4");
+        this.moveWorker.Move("h1h3");
         
-        Assert.Equal(GameEvent.MoveSucceeded, moveWorker.Move("h2h3"));
-        Assert.Equal(GameEvent.MoveSucceeded, moveWorker.Move("h3h4"));
-        Assert.Equal(GameEvent.MoveSucceeded, moveWorker.Move("h1h3"));
-        
-        Assert.Equal(GameEvent.InvalidMove, moveWorker.Move("h3e6"));
-        Assert.Equal(GameEvent.MoveSucceeded, moveWorker.Move("h3d7"));
+        Assert.Equal(GameEvent.InvalidMove,     this.moveWorker.Move("h3e6"));
+        Assert.Equal(GameEvent.MoveSucceeded,   this.moveWorker.Move("h3d7"));
 
     }
 
     [Fact]
-    public void MoveLikeBishop_captureLikeKnight()
+    public void MoveLikeBishop_CaptureLikeKnight()
     {
-        var moveWorker = new MoveWorker(Chessboard.StandardChessboard(), Piece.AllStandardPieces());
-
         var patterns = new List<IPattern> {
             new RegularPattern(Constants.NorthEast, 1, 8),
             new RegularPattern(Constants.SouthEast, 1, 8),
@@ -450,23 +432,22 @@ public class ChessboardTests //: IDisposable
 
         var mp = new MovementPattern(patterns);
         var cp = new MovementPattern(capturePattern);
-        Piece piece = new Piece(mp, cp, false, PieceClassifier.WHITE, "C");
+        Piece piece = new Piece(mp, cp, false, PieceClassifier.WHITE, "CA");
 
-        Assert.True(moveWorker.InsertOnBoard(piece, "h1"));
+        this.moveWorker.InsertOnBoard(piece, "h1");
         
-        Assert.Equal(GameEvent.InvalidMove,     moveWorker.Move("h1g3"));
-        Assert.Equal(GameEvent.MoveSucceeded,   moveWorker.Move("g2g3"));
-        Assert.Equal(GameEvent.InvalidMove,     moveWorker.Move("h1b7"));
-        Assert.Equal(GameEvent.MoveSucceeded,   moveWorker.Move("h1c6"));
-        
-        Assert.Equal(GameEvent.MoveSucceeded, moveWorker.Move("c6d8"));
+        Assert.Equal(GameEvent.InvalidMove,     this.moveWorker.Move("h1g3"));
+        Assert.Equal(GameEvent.MoveSucceeded,   this.moveWorker.Move("g2g3"));
+        Assert.Equal(GameEvent.InvalidMove,     this.moveWorker.Move("h1b7"));
+        Assert.Equal(GameEvent.MoveSucceeded,   this.moveWorker.Move("h1c6"));
+        Assert.Equal(GameEvent.MoveSucceeded,   this.moveWorker.Move("c6d8"));
 
     }
 
     [Fact]
     public void TestJumpCapturePattern()
     {
-        var moveWorker = new MoveWorker(new Chessboard(8));
+        this.moveWorker.Board = new Chessboard(8);
 
         var patterns = new List<IPattern> {
             new JumpPattern( 1, 2),
@@ -488,11 +469,12 @@ public class ChessboardTests //: IDisposable
         
         var mp = new MovementPattern(patterns);
         var cp = new  MovementPattern(capturePatterns);
-        Piece piece1 = new Piece(mp, cp, false, PieceClassifier.WHITE , "C");
+        Piece piece1 = new Piece(mp, cp, false, PieceClassifier.WHITE , "CA");
         Piece piece2 = Piece.BlackPawn();
         
-        Assert.True(moveWorker.InsertOnBoard(piece1, "d4"));
-        Assert.True(moveWorker.InsertOnBoard(piece2, "e7"));
-        Assert.Equal(GameEvent.MoveSucceeded, moveWorker.Move("d4e7"));
+        this.moveWorker.InsertOnBoard(piece1, "d4");
+        this.moveWorker.InsertOnBoard(piece2, "e7");
+
+        Assert.Equal(GameEvent.MoveSucceeded, this.moveWorker.Move("d4e7"));
     }
 }

--- a/ChessVariantsLogic.Tests/ChessboardTests.cs
+++ b/ChessVariantsLogic.Tests/ChessboardTests.cs
@@ -7,8 +7,24 @@ namespace ChessVariantsLogic.Tests;
 /// <summary>
 /// This class contains unit tests on Chessboard.cs and ChessDriver.cs.
 /// </summary>
-public class ChessboardTests
+public class ChessboardTests //: IDisposable
 {
+    /*private MoveWorker moveWorker;
+    private Chessboard board;
+
+    public ChessboardTests()
+    {
+        this.board = Chessboard.StandardChessboard();
+        this.moveWorker = new MoveWorker(this.board, Piece.AllStandardPieces());
+    }
+
+    public void Dispose()
+    {
+        this.board = new Chessboard(8);
+        this.moveWorker = new MoveWorker(this.board);
+        GC.SuppressFinalize(this);
+    }
+    */
 
     /// <summary>
     /// Tests that the FEN representation of the board is of the correct format.

--- a/ChessVariantsLogic.Tests/ChessboardTests.cs
+++ b/ChessVariantsLogic.Tests/ChessboardTests.cs
@@ -1,6 +1,7 @@
 using ChessVariantsLogic.Rules.Moves;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using Xunit;
 
 namespace ChessVariantsLogic.Tests;
@@ -374,13 +375,21 @@ public class ChessboardTests : IDisposable
     [Fact]
     public void MoveLogCorrectlySavesAllMoves()
     {
-        this.moveWorker.Move("h2h3");
-        this.moveWorker.Move("h3h4");
-        this.moveWorker.Move("h1h3");
-        this.moveWorker.Move("h3e3");
-        
-        var expected = new List<string> {"h2h3","h3h4","h1h3","h3e3"};
-        Assert.Equal(expected, this.moveWorker.Movelog);
+        var moves = new List<Move> {
+            new Move("h2h3", PieceClassifier.WHITE),
+            new Move("h3h4", PieceClassifier.WHITE),
+            new Move("h1h3", PieceClassifier.WHITE),
+            new Move("h3e3", PieceClassifier.WHITE),
+        };
+
+        foreach (var move in moves)
+        {
+            move.Perform(moveWorker);
+        }
+
+        var expected = new List<string> { "h2h3", "h3h4", "h1h3", "h3e3" };
+        var actual = moveWorker.Movelog.Select(move => move.FromTo).ToList();
+        Assert.Equal(expected, actual);
     }
 
     [Fact]

--- a/ChessVariantsLogic/Movement/IPattern.cs
+++ b/ChessVariantsLogic/Movement/IPattern.cs
@@ -10,23 +10,25 @@ public interface IPattern
     /// Gets the direction in the X-axis.
     /// </summary>
     /// <returns>the direction in the X-axis as an integer.</returns>
-    int GetXDir();
+    int XDir { get;}
 
     /// <summary>
     /// Gets the direction in the Y-axis.
     /// </summary>
     /// <returns>the direction in the Y-axis as an integer.</returns>
-    int GetYDir();
+
+    int YDir { get; }
 
     /// <summary>
     /// Gets the minimum length that this pattern requires to be travelled.
     /// </summary>
     /// <returns>the minimuim length as an integer.</returns>
-    int GetMinLength();
+    int MinLength { get; }
 
-        /// <summary>
+    /// <summary>
     /// Gets the maximum length that this pattern allows to be travelled.
     /// </summary>
     /// <returns>the maximum length as an integer.</returns>
-    int GetMaxLength();
+    int MaxLength { get; } 
+
 }

--- a/ChessVariantsLogic/Movement/JumpPattern.cs
+++ b/ChessVariantsLogic/Movement/JumpPattern.cs
@@ -5,31 +5,37 @@ namespace ChessVariantsLogic;
 /// </summary>
 public class JumpPattern : IPattern
 {
+    private readonly int xDir;
+    private readonly int yDir;
+
     private readonly Tuple<int, int> pattern;
 
     public JumpPattern(int xOffset, int yOffset)
     {
+        this.xDir = xOffset;
+        this.yDir = yOffset;
         this.pattern = new Tuple<int, int>(xOffset, yOffset);
     }
 
 #region Interface overrides
+
     ///<inheritdoc /> 
-    public int GetXDir() { return pattern.Item1; }
-
+    public int XDir {get {return this.xDir; } }
+    
     /// <inheritdoc /> 
-    public int GetYDir() { return pattern.Item2; }
+    public int YDir {get {return this.yDir; } }
 
     /// <summary>
     /// Exists to satisfy interface.
     /// </summary>
     /// <returns>-1</returns>
-    public int GetMinLength() { return -1; }
+    public int MinLength {get {return -1; } }
 
     /// <summary>
     /// Exists to satisfy interface.
     /// </summary>
     /// <returns>-1</returns>
-    public int GetMaxLength() { return -1; }
+    public int MaxLength {get {return -1; } }
 
 #endregion
 

--- a/ChessVariantsLogic/Movement/JumpPattern.cs
+++ b/ChessVariantsLogic/Movement/JumpPattern.cs
@@ -8,14 +8,13 @@ public class JumpPattern : IPattern
     private readonly int xDir;
     private readonly int yDir;
 
-    private readonly Tuple<int, int> pattern;
-
     public JumpPattern(int xOffset, int yOffset)
     {
         this.xDir = xOffset;
         this.yDir = yOffset;
-        this.pattern = new Tuple<int, int>(xOffset, yOffset);
     }
+
+    public JumpPattern(Tuple<int,int> offsets) : this(offsets.Item1, offsets.Item2) {}
 
 #region Interface overrides
 

--- a/ChessVariantsLogic/Movement/MoveWorker.cs
+++ b/ChessVariantsLogic/Movement/MoveWorker.cs
@@ -269,10 +269,10 @@ public class MoveWorker
         if(pattern != null)
         
         
-            for (int j = pattern.GetMinLength(); j < maxIndex; j++)
+            for (int j = pattern.MinLength; j < maxIndex; j++)
             {
-                int newRow = pos.Item1 + pattern.GetXDir() * j;
-                int newCol = pos.Item2 + pattern.GetYDir() * j;
+                int newRow = pos.Item1 + pattern.XDir * j;
+                int newCol = pos.Item2 + pattern.YDir * j;
 
                 if(!insideBoard(newRow, newCol))
                     break;
@@ -283,8 +283,8 @@ public class MoveWorker
                 if(pieceIdentifier1 == null || pieceIdentifier2 == null || hasTaken(piece, pos))
                     break;
 
-                var minLength = pattern.GetMinLength();
-                var maxLength = pattern.GetMaxLength();
+                var minLength = pattern.MinLength;
+                var maxLength = pattern.MaxLength;
 
                 if(maxLength < j || j < minLength)
                     break;
@@ -312,8 +312,8 @@ public class MoveWorker
             if (pattern == null)
                 continue;
 
-            int newRow = pos.Item1 + pattern.GetXDir() * j;
-            int newCol = pos.Item2 + pattern.GetYDir() * j;
+            int newRow = pos.Item1 + pattern.XDir * j;
+            int newCol = pos.Item2 + pattern.YDir * j;
 
             if (!insideBoard(newRow, newCol))
                 break;
@@ -324,8 +324,8 @@ public class MoveWorker
             if (pieceIdentifier1 == null || pieceIdentifier2 == null || hasTaken(piece, pos))
                 continue;
 
-            var minLength = pattern.GetMinLength();
-            var maxLength = pattern.GetMaxLength();
+            var minLength = pattern.MinLength;
+            var maxLength = pattern.MaxLength;
 
             if (maxLength < j || j < minLength)
                 continue;
@@ -362,8 +362,8 @@ public class MoveWorker
     {
         var moves = new HashSet<Tuple<int, int>>();
 
-        int newRow = pos.Item1 + pattern.GetXDir();
-        int newCol = pos.Item2 + pattern.GetYDir();
+        int newRow = pos.Item1 + pattern.XDir;
+        int newCol = pos.Item2 + pattern.YDir;
 
         string? pieceIdentifier1 = board.GetPieceIdentifier(pos);
         string? pieceIdentifier2 = board.GetPieceIdentifier(newRow, newCol);
@@ -385,8 +385,8 @@ public class MoveWorker
         if (pattern == null)
             return null;
 
-        int newRow = pos.Item1 + pattern.GetXDir();
-        int newCol = pos.Item2 + pattern.GetYDir();
+        int newRow = pos.Item1 + pattern.XDir;
+        int newCol = pos.Item2 + pattern.YDir;
 
         string? pieceIdentifier1 = board.GetPieceIdentifier(pos);
         string? pieceIdentifier2 = board.GetPieceIdentifier(newRow, newCol);

--- a/ChessVariantsLogic/Movement/MoveWorker.cs
+++ b/ChessVariantsLogic/Movement/MoveWorker.cs
@@ -418,7 +418,7 @@ public class MoveWorker
     /// </summary>
     /// <param name="player"> is the player whose moves should be calculated. </param>
     /// <returns>an iterable collection of all valid capture moves.</returns>
-    public HashSet<string> GetAllCaptureMoves(Player player)
+    public HashSet<string> GetAllCapturePatternMoves(Player player)
     {
         var coorMoves = new HashSet<(Tuple<int,int>, Tuple<int,int>)>();
 

--- a/ChessVariantsLogic/Movement/RegularPattern.cs
+++ b/ChessVariantsLogic/Movement/RegularPattern.cs
@@ -10,15 +10,12 @@ public class RegularPattern : IPattern
     private readonly int minLength;
     private readonly int maxLength;
 
-    private readonly Tuple<int, int, int, int> pattern;
-
     public RegularPattern(int xDir, int yDir, int minLength, int maxLength)
     {
         this.xDir = xDir;
         this.yDir = yDir;
         this.minLength = minLength;
         this.maxLength = maxLength;
-        this.pattern = new Tuple<int,int,int,int>(xDir, yDir, minLength, maxLength);
     }
 
     public RegularPattern(Tuple<int,int> direction, int minLength, int maxLength) : this(direction.Item1, direction.Item2, minLength, maxLength) {}

--- a/ChessVariantsLogic/Movement/RegularPattern.cs
+++ b/ChessVariantsLogic/Movement/RegularPattern.cs
@@ -5,10 +5,19 @@ namespace ChessVariantsLogic;
 /// </summary>
 public class RegularPattern : IPattern
 {
+    private readonly int xDir;
+    private readonly int yDir;
+    private readonly int minLength;
+    private readonly int maxLength;
+
     private readonly Tuple<int, int, int, int> pattern;
 
     public RegularPattern(int xDir, int yDir, int minLength, int maxLength)
     {
+        this.xDir = xDir;
+        this.yDir = yDir;
+        this.minLength = minLength;
+        this.maxLength = maxLength;
         this.pattern = new Tuple<int,int,int,int>(xDir, yDir, minLength, maxLength);
     }
 
@@ -17,16 +26,13 @@ public class RegularPattern : IPattern
 #region Interface overrides
 
     /// <inheritdoc /> 
-    public int GetXDir() { return pattern.Item1; }
-
-    ///<inheritdoc /> 
-    public int GetYDir() { return pattern.Item2; }
-    
-    ///<inheritdoc />
-    public int GetMinLength() { return pattern.Item3; }
-
-    ///<inheritdoc />
-    public int GetMaxLength() { return pattern.Item4; }
+    public int XDir {get {return this.xDir; } }
+    /// <inheritdoc /> 
+    public int YDir {get {return this.yDir; } }
+    /// <inheritdoc /> 
+    public int MinLength {get {return this.minLength; } }
+    /// <inheritdoc /> 
+    public int MaxLength {get {return this.maxLength; } }
 
 #endregion
 

--- a/ChessVariantsLogic/Rules/Predicates/ChessPredicates/Utils.cs
+++ b/ChessVariantsLogic/Rules/Predicates/ChessPredicates/Utils.cs
@@ -19,7 +19,7 @@ public class Utils
         var player = GetPlayer(pieceIdentifier);
         var attacker = player == Player.White ? Player.Black : Player.White;
         var piecePositions = FindPiecesOfType(board, pieceIdentifier);
-        var attackedPieces = board.GetAllCaptureMoves(attacker);
+        var attackedPieces = board.GetAllCapturePatternMoves(attacker);
         foreach (var attackerMove in attackedPieces)
         {
             var (_, to) = board.ParseMove(attackerMove);
@@ -39,7 +39,7 @@ public class Utils
     /// <returns>True if the square with coordinate <paramref name="position"/> is attacked by <paramref name="attacker"/> </returns>
     public static bool SquareAttacked(MoveWorker board, string position, Player attacker)
     {
-        var attackedPieces = board.GetAllCaptureMoves(attacker);
+        var attackedPieces = board.GetAllCapturePatternMoves(attacker);
         foreach (var attackerMove in attackedPieces)
         {
             var (_, to) = board.ParseMove(attackerMove);


### PR DESCRIPTION
This PR contains changes suggested in the PR #11 that were decided to be implemented at a later time. That time is now.

- Remove unnecessary representation by Tuple in the classes JumpMovementPattern and RegularMovementPattern. These classes instead holds separate fields for each value. Consequently, the interface IPattern has been updated to contain properties of these fields instead of the previous getter-methods.
- Refactor ChessboardTests by removing dependency to GameEvent, not asserting things irrelevant to the test itself and by renaming the tests for increased interpretability. Notice that some tests have documentation while others have not: I believe we decided to not document the test unless absolutely necessary as they should be descriptive and therefore I did not write documentation for new tests, but I also did not remove already existing documentation. Please correct me if I misunderstood this :D 

Also, the test "Test_FEN" is still included, but I believe the method "ReadBoardAsFEN" will not be required following the implementation of GameExporter.

Happy reviewing!