### PR TITLE
Implementation of Event System

### DIFF
--- a/ChessVariantsLogic.Tests/RulesTests/ChessPredicateTests/PositionHasRankTests.cs
+++ b/ChessVariantsLogic.Tests/RulesTests/ChessPredicateTests/PositionHasRankTests.cs
@@ -1,0 +1,35 @@
+using Xunit;
+using ChessVariantsLogic.Rules.Predicates;
+using ChessVariantsLogic.Rules.Predicates.ChessPredicates;
+using ChessVariantsLogic.Rules;
+using ChessVariantsLogic.Rules.Moves;
+
+namespace ChessVariantsLogic.Tests;
+
+public class PositionHasRankTests {
+    private readonly MoveWorker board;
+    
+    private readonly BoardTransition transition;
+
+    public PositionHasRankTests()
+    {
+        board = new MoveWorker(Chessboard.StandardChessboard(), Piece.AllStandardPieces());
+        Move move = new Move("e2e3", PieceClassifier.WHITE);
+        transition = new BoardTransition(board, move);
+    }
+
+    [Fact]
+    public void PawnHasRankThree_ShouldReturnTrue()
+    {
+        IPredicate pawnHasRankThree = new PositionHasRank(new PositionRelative(0, 0), 3, RelativeTo.TO);
+        Assert.True(pawnHasRankThree.Evaluate(transition));
+    }
+
+    [Fact]
+    public void PawnHasRankThree_ShouldReturnFalse()
+    {
+        IPredicate pawnHasRankThree = new PositionHasRank(new PositionRelative(0, 0), 3, RelativeTo.FROM);
+        Assert.False(pawnHasRankThree.Evaluate(transition));
+    }
+
+}

--- a/ChessVariantsLogic/Chessboard.cs
+++ b/ChessVariantsLogic/Chessboard.cs
@@ -158,41 +158,6 @@ public class Chessboard
         return chessboard;
     }
 
-    /// <returns> an instance of Chessboard with the standard set up. </returns>
-    public static Chessboard TestBoard()
-    {
-        var chessboard = new Chessboard(8);
-
-        chessboard.board[0, 0] = Constants.BlackRookIdentifier;
-        chessboard.board[0, 1] = Constants.BlackKnightIdentifier;
-        chessboard.board[0, 2] = Constants.BlackBishopIdentifier;
-        chessboard.board[0, 3] = Constants.BlackQueenIdentifier;
-        chessboard.board[0, 4] = Constants.BlackKingIdentifier;
-        chessboard.board[0, 5] = Constants.UnoccupiedSquareIdentifier;
-        chessboard.board[0, 6] = Constants.BlackKnightIdentifier;
-        chessboard.board[0, 7] = Constants.BlackRookIdentifier;
-
-
-        chessboard.fillRank(1, Constants.BlackPawnIdentifier);
-        chessboard.board[1, 5] = Constants.WhitePawnIdentifier;
-        chessboard.fillRank(2, Constants.UnoccupiedSquareIdentifier);
-        chessboard.fillRank(3, Constants.UnoccupiedSquareIdentifier);
-        chessboard.fillRank(4, Constants.UnoccupiedSquareIdentifier);
-        chessboard.fillRank(5, Constants.UnoccupiedSquareIdentifier);
-        chessboard.fillRank(6, Constants.WhitePawnIdentifier);
-
-        chessboard.board[7, 0] = Constants.WhiteRookIdentifier;
-        chessboard.board[7, 1] = Constants.WhiteKnightIdentifier;
-        chessboard.board[7, 2] = Constants.WhiteBishopIdentifier;
-        chessboard.board[7, 3] = Constants.WhiteQueenIdentifier;
-        chessboard.board[7, 4] = Constants.WhiteKingIdentifier;
-        chessboard.board[7, 5] = Constants.WhiteBishopIdentifier;
-        chessboard.board[7, 6] = Constants.WhiteKnightIdentifier;
-        chessboard.board[7, 7] = Constants.WhiteRookIdentifier;
-
-        return chessboard;
-    }
-
     /// <returns> an instance of Chessboard with the duck chess set up. </returns>
     public static Chessboard DuckChessboard()
     {

--- a/ChessVariantsLogic/Chessboard.cs
+++ b/ChessVariantsLogic/Chessboard.cs
@@ -137,14 +137,50 @@ public class Chessboard
         chessboard.board[0, 5] = Constants.BlackBishopIdentifier;
         chessboard.board[0, 6] = Constants.BlackKnightIdentifier;
         chessboard.board[0, 7] = Constants.BlackRookIdentifier;
-        
+
+
         chessboard.fillRank(1, Constants.BlackPawnIdentifier);
         chessboard.fillRank(2, Constants.UnoccupiedSquareIdentifier);
         chessboard.fillRank(3, Constants.UnoccupiedSquareIdentifier);
         chessboard.fillRank(4, Constants.UnoccupiedSquareIdentifier);
         chessboard.fillRank(5, Constants.UnoccupiedSquareIdentifier);
         chessboard.fillRank(6, Constants.WhitePawnIdentifier);
-        
+
+        chessboard.board[7, 0] = Constants.WhiteRookIdentifier;
+        chessboard.board[7, 1] = Constants.WhiteKnightIdentifier;
+        chessboard.board[7, 2] = Constants.WhiteBishopIdentifier;
+        chessboard.board[7, 3] = Constants.WhiteQueenIdentifier;
+        chessboard.board[7, 4] = Constants.WhiteKingIdentifier;
+        chessboard.board[7, 5] = Constants.WhiteBishopIdentifier;
+        chessboard.board[7, 6] = Constants.WhiteKnightIdentifier;
+        chessboard.board[7, 7] = Constants.WhiteRookIdentifier;
+
+        return chessboard;
+    }
+
+    /// <returns> an instance of Chessboard with the standard set up. </returns>
+    public static Chessboard TestBoard()
+    {
+        var chessboard = new Chessboard(8);
+
+        chessboard.board[0, 0] = Constants.BlackRookIdentifier;
+        chessboard.board[0, 1] = Constants.BlackKnightIdentifier;
+        chessboard.board[0, 2] = Constants.BlackBishopIdentifier;
+        chessboard.board[0, 3] = Constants.BlackQueenIdentifier;
+        chessboard.board[0, 4] = Constants.BlackKingIdentifier;
+        chessboard.board[0, 5] = Constants.UnoccupiedSquareIdentifier;
+        chessboard.board[0, 6] = Constants.BlackKnightIdentifier;
+        chessboard.board[0, 7] = Constants.BlackRookIdentifier;
+
+
+        chessboard.fillRank(1, Constants.BlackPawnIdentifier);
+        chessboard.board[1, 5] = Constants.WhitePawnIdentifier;
+        chessboard.fillRank(2, Constants.UnoccupiedSquareIdentifier);
+        chessboard.fillRank(3, Constants.UnoccupiedSquareIdentifier);
+        chessboard.fillRank(4, Constants.UnoccupiedSquareIdentifier);
+        chessboard.fillRank(5, Constants.UnoccupiedSquareIdentifier);
+        chessboard.fillRank(6, Constants.WhitePawnIdentifier);
+
         chessboard.board[7, 0] = Constants.WhiteRookIdentifier;
         chessboard.board[7, 1] = Constants.WhiteKnightIdentifier;
         chessboard.board[7, 2] = Constants.WhiteBishopIdentifier;

--- a/ChessVariantsLogic/Game.cs
+++ b/ChessVariantsLogic/Game.cs
@@ -44,6 +44,7 @@ public class Game {
     /// <returns>GameEvent of what happened in the game</returns>
     private GameEvent MakeMoveImpl(string moveCoordinates) {
         IEnumerable<Move> validMoves;
+
         if (_playerTurn == Player.White) {
             validMoves = _whiteRules.ApplyMoveRule(_moveWorker, _playerTurn);
         } else {
@@ -52,11 +53,24 @@ public class Game {
         Move? move = GetMove(validMoves, moveCoordinates);
         if (move == null) return GameEvent.InvalidMove;
         if (validMoves.Contains(move)) {
-        
+
+
+            BoardTransition transition = new BoardTransition(_moveWorker.CopyBoardState(), move);
+
             GameEvent gameEvent = move.Perform(_moveWorker);
 
-            if(gameEvent == GameEvent.InvalidMove)
+            if (_playerTurn == Player.White)
+            {
+                _whiteRules.RunEvents(transition, _moveWorker);
+            }
+            else
+            {
+                _blackRules.RunEvents(transition, _moveWorker);
+            }
+
+            if (gameEvent == GameEvent.InvalidMove)
                 return gameEvent;
+
 
             /// TODO: Check for a tie
 

--- a/ChessVariantsLogic/GameFactory.cs
+++ b/ChessVariantsLogic/GameFactory.cs
@@ -23,6 +23,7 @@ public static class GameFactory
     public const string CaptureTheKingIdentifier = "captureTheKing";
     public const string AntiChessIdentifier = "antiChess";
     public const string DuckChessIdentifier = "duckChess";
+    public const string AtomicChessIdentifier = "atomicChess";
 
     public static Game StandardChess()
     {
@@ -160,6 +161,9 @@ public static class GameFactory
 
     }
 
+    // This is just for fun and to show that the event system is general.
+    // More info: https://en.wikipedia.org/wiki/Atomic_chess
+
     public static Game AtomicChess()
     {
         IPredicate blackKingCheckedThisTurn = new Attacked(BoardState.THIS, Constants.BlackKingIdentifier);
@@ -259,6 +263,7 @@ public static class GameFactory
             AntiChessIdentifier => AntiChess(),
             CaptureTheKingIdentifier => CaptureTheKing(),
             DuckChessIdentifier => DuckChess(),
+            AtomicChessIdentifier => AtomicChess(),
             _ => throw new ArgumentException($"No variant corresponds to identifier: {identifier}"),
         };
 

--- a/ChessVariantsLogic/GameFactory.cs
+++ b/ChessVariantsLogic/GameFactory.cs
@@ -33,14 +33,14 @@ public static class GameFactory
 
         IPredicate blackKingCheckedThisAndNextTurn = new Operator(blackKingCheckedThisTurn, AND, blackKingCheckedNextTurn);
         IPredicate whiteKingCheckedThisAndNextTurn = new Operator(whiteKingCheckedThisTurn, AND, whiteKingCheckedNextTurn);
-        
-        IPredicate whiteWinRule = new ForEvery(blackKingCheckedThisAndNextTurn, Player.Black);  
+
+        IPredicate whiteWinRule = new ForEvery(blackKingCheckedThisAndNextTurn, Player.Black);
         IPredicate blackWinRule = new ForEvery(whiteKingCheckedThisAndNextTurn, Player.White);
 
-        IPredicate whiteMoveRule = new Operator(NOT, whiteKingCheckedNextTurn);        
+        IPredicate whiteMoveRule = new Operator(NOT, whiteKingCheckedNextTurn);
         IPredicate blackMoveRule = new Operator(NOT, blackKingCheckedNextTurn);
 
-        
+
 
         ISet<MoveTemplate> movesWhite = new HashSet<MoveTemplate>
         {
@@ -61,13 +61,18 @@ public static class GameFactory
             MoveTemplate.EnPassantMove(Player.Black, false),
         };
 
+        ISet<Event> eventsWhite = new HashSet<Event> { Event.PromotionEvent(Player.White, 8) };
+        ISet<Event> eventsBlack = new HashSet<Event> { Event.PromotionEvent(Player.Black, 8) };
 
-        RuleSet rulesWhite = new RuleSet(whiteMoveRule, whiteWinRule, movesWhite);
-        RuleSet rulesBlack = new RuleSet(blackMoveRule, blackWinRule, movesBlack);
+
+
+        RuleSet rulesWhite = new RuleSet(whiteMoveRule, whiteWinRule, movesWhite, eventsWhite);
+        RuleSet rulesBlack = new RuleSet(blackMoveRule, blackWinRule, movesBlack, eventsBlack);
 
 
         return new Game(new MoveWorker(Chessboard.StandardChessboard(), Piece.AllStandardPieces()), Player.White, 1, rulesWhite, rulesBlack);
     }
+
 
     public static Game CaptureTheKing()
     {
@@ -97,9 +102,12 @@ public static class GameFactory
             MoveTemplate.EnPassantMove(Player.Black, false),
         };
 
-        RuleSet rulesWhite = new RuleSet(whiteMoveRule, whiteWinRule, movesWhite);
-        RuleSet rulesBlack = new RuleSet(blackMoveRule, blackWinRule, movesBlack);
+        ISet<Event> eventsWhite = new HashSet<Event> { Event.PromotionEvent(Player.White, 8) };
+        ISet<Event> eventsBlack = new HashSet<Event> { Event.PromotionEvent(Player.Black, 8) };
 
+
+        RuleSet rulesWhite = new RuleSet(whiteMoveRule, whiteWinRule, movesWhite, eventsWhite);
+        RuleSet rulesBlack = new RuleSet(blackMoveRule, blackWinRule, movesBlack, eventsBlack);
 
         return new Game(new MoveWorker(Chessboard.StandardChessboard(), Piece.AllStandardPieces()), Player.White, 1, rulesWhite, rulesBlack);
 
@@ -141,14 +149,87 @@ public static class GameFactory
             MoveTemplate.EnPassantMove(Player.Black, false),
         };
 
-        RuleSet rulesWhite = new RuleSet(whiteMoveRule, whiteWinRule, movesWhite);
-        RuleSet rulesBlack = new RuleSet(blackMoveRule, blackWinRule, movesBlack);
+        ISet<Event> eventsWhite = new HashSet<Event> { Event.PromotionEvent(Player.White, 8) };
+        ISet<Event> eventsBlack = new HashSet<Event> { Event.PromotionEvent(Player.Black, 8) };
+
+        RuleSet rulesWhite = new RuleSet(whiteMoveRule, whiteWinRule, movesWhite, eventsWhite);
+        RuleSet rulesBlack = new RuleSet(blackMoveRule, blackWinRule, movesBlack, eventsBlack);
 
 
         return new Game(new MoveWorker(Chessboard.DuckChessboard(), Piece.AllDuckChessPieces()), Player.White, 2, rulesWhite, rulesBlack);
 
     }
 
+    public static Game AtomicChess()
+    {
+        IPredicate blackKingCheckedThisTurn = new Attacked(BoardState.THIS, Constants.BlackKingIdentifier);
+        IPredicate blackKingCheckedNextTurn = new Attacked(BoardState.NEXT, Constants.BlackKingIdentifier);
+        IPredicate whiteKingCheckedThisTurn = new Attacked(BoardState.THIS, Constants.WhiteKingIdentifier);
+        IPredicate whiteKingCheckedNextTurn = new Attacked(BoardState.NEXT, Constants.WhiteKingIdentifier);
+
+        IPredicate blackKingCheckedThisAndNextTurn = new Operator(blackKingCheckedThisTurn, AND, blackKingCheckedNextTurn);
+        IPredicate whiteKingCheckedThisAndNextTurn = new Operator(whiteKingCheckedThisTurn, AND, whiteKingCheckedNextTurn);
+
+
+        IPredicate checkMateWhite = new ForEvery(blackKingCheckedThisAndNextTurn, Player.Black);
+        IPredicate checkMateBlack = new ForEvery(whiteKingCheckedThisAndNextTurn, Player.White);
+
+        IPredicate noBlackKingLeft = new PiecesLeft(Constants.BlackKingIdentifier, Comparator.EQUALS, 0, BoardState.THIS);
+        IPredicate noWhiteKingLeft = new PiecesLeft(Constants.WhiteKingIdentifier, Comparator.EQUALS, 0, BoardState.THIS);
+
+        IPredicate whiteCaptured = new PieceCaptured("ANY_WHITE");
+        IPredicate blackCaptured = new PieceCaptured("ANY_BLACK");
+
+        IPredicate whiteKingMoved = new PieceMoved(Constants.WhiteKingIdentifier);
+        IPredicate blackKingMoved = new PieceMoved(Constants.BlackKingIdentifier);
+
+        IPredicate whiteMoveRule = new Operator(NOT, whiteKingCheckedNextTurn) & !(blackCaptured & whiteKingMoved);
+        IPredicate blackMoveRule = new Operator(NOT, blackKingCheckedNextTurn) & !(whiteCaptured & blackKingMoved);
+
+        IPredicate whiteWinRule = checkMateWhite | noBlackKingLeft;
+        IPredicate blackWinRule = checkMateBlack | noWhiteKingLeft;
+
+
+        ISet<MoveTemplate> movesWhite = new HashSet<MoveTemplate>
+        {
+            MoveTemplate.CastleMove(Player.White, true, false),
+            MoveTemplate.CastleMove(Player.White, false, false),
+            MoveTemplate.PawnDoubleMove(Player.White),
+            MoveTemplate.EnPassantMove(Player.White, true),
+            MoveTemplate.EnPassantMove(Player.White, false),
+        };
+
+
+        ISet<MoveTemplate> movesBlack = new HashSet<MoveTemplate>
+        {
+            MoveTemplate.CastleMove(Player.Black, true, false),
+            MoveTemplate.CastleMove(Player.Black, false, false),
+            MoveTemplate.PawnDoubleMove(Player.Black),
+            MoveTemplate.EnPassantMove(Player.Black, true),
+            MoveTemplate.EnPassantMove(Player.Black, false),
+        };
+
+        ISet<Event> eventsWhite = new HashSet<Event> { Event.PromotionEvent(Player.White, 8) };
+        ISet<Event> eventsBlack = new HashSet<Event> { Event.PromotionEvent(Player.Black, 8) };
+
+
+        for (int x = -1; x < 2; x++)
+        {
+            for (int y = -1; y < 2; y++)
+            {
+                IPosition position = new PositionRelative(y, x);
+                eventsWhite.Add(Event.ExplosionEvent(Player.White, position));
+                eventsBlack.Add(Event.ExplosionEvent(Player.Black, position));
+            }
+        }
+
+
+        RuleSet rulesWhite = new RuleSet(whiteMoveRule, whiteWinRule, movesWhite, eventsWhite);
+        RuleSet rulesBlack = new RuleSet(blackMoveRule, blackWinRule, movesBlack, eventsBlack);
+
+
+        return new Game(new MoveWorker(Chessboard.StandardChessboard(), Piece.AllStandardPieces()), Player.White, 1, rulesWhite, rulesBlack);
+    }
     public static Game AntiChess()
     {
         

--- a/ChessVariantsLogic/GameFactory.cs
+++ b/ChessVariantsLogic/GameFactory.cs
@@ -222,8 +222,9 @@ public static class GameFactory
             for (int y = -1; y < 2; y++)
             {
                 IPosition position = new PositionRelative(y, x);
-                eventsWhite.Add(Event.ExplosionEvent(Player.White, position));
-                eventsBlack.Add(Event.ExplosionEvent(Player.Black, position));
+                bool shouldDestroyPawn = (x == 0 && y == 0);
+                eventsWhite.Add(Event.ExplosionEvent(Player.White, position, shouldDestroyPawn));
+                eventsBlack.Add(Event.ExplosionEvent(Player.Black, position, shouldDestroyPawn));
             }
         }
 

--- a/ChessVariantsLogic/Rules/Event.cs
+++ b/ChessVariantsLogic/Rules/Event.cs
@@ -1,0 +1,67 @@
+﻿
+using ChessVariantsLogic.Rules.Moves;
+using ChessVariantsLogic.Rules.Moves.Actions;
+using ChessVariantsLogic.Rules.Predicates;
+using ChessVariantsLogic.Rules.Predicates.ChessPredicates;
+
+namespace ChessVariantsLogic.Rules;
+public class Event
+{
+    private readonly IPredicate _predicate;
+    private readonly ISet<IAction> _actions;
+    private readonly RelativeTo _relativeTo;
+
+    public Event(IPredicate predicate, ISet<IAction> actions, RelativeTo relativeTo)
+    {
+        _predicate = predicate;
+        _actions = actions;
+        _relativeTo = relativeTo;
+    }
+
+    public bool ShouldRun(BoardTransition lastTransition)
+    {
+        return _predicate.Evaluate(lastTransition);
+    }
+
+    public GameEvent Run(MoveWorker moveWorker)
+    {
+        Move lastMove = moveWorker.getLastMove();
+
+        var (from, to) = MoveWorker.ParseMove(lastMove.FromTo);
+
+        string move = _relativeTo == RelativeTo.FROM ? from + from : to + to;
+        
+        Move moveEvent = new Move(_actions, move, lastMove.PieceClassifier);
+
+        return moveEvent.Perform(moveWorker);
+    }
+
+
+    public static Event PromotionEvent(Player player, int boardHeight)
+    {
+        string pawnIdentifier = player == Player.White ? Constants.WhitePawnIdentifier : Constants.BlackPawnIdentifier;
+        string queenIdentifier = player == Player.White ? Constants.WhiteQueenIdentifier : Constants.BlackQueenIdentifier;
+        int rank = player == Player.White ? 0 : (boardHeight-1);
+
+        IPredicate pawnMoved = new PieceMoved(pawnIdentifier);
+        IPredicate pawnAtRank = new PositionHasRank(new PositionRelative(0, 0), rank, RelativeTo.TO);
+
+        ISet<IAction> actions = new HashSet<IAction> { new ActionSetPiece(new PositionRelative(0, 0), queenIdentifier) };
+
+        return new Event(pawnMoved & pawnAtRank, actions, RelativeTo.TO);
+    }
+
+
+    public static Event ExplosionEvent(Player player, IPosition pos)
+    {
+        string oppositePawnIdentifier = player == Player.White ? Constants.BlackPawnIdentifier : Constants.WhitePawnIdentifier;
+        IPredicate pieceCaptured = player == Player.White ? new PieceCaptured("ANY_BLACK") : new PieceCaptured("ANY_WHITE");
+        IPredicate oppositePawnAt = new PieceAt(oppositePawnIdentifier, pos, BoardState.NEXT, RelativeTo.TO);
+
+        ISet<IAction> actions = new HashSet<IAction> { new ActionSetPiece(pos, Constants.UnoccupiedSquareIdentifier)};
+
+        return new Event(pieceCaptured & !oppositePawnAt, actions, RelativeTo.TO);
+    }
+
+
+}

--- a/ChessVariantsLogic/Rules/Event.cs
+++ b/ChessVariantsLogic/Rules/Event.cs
@@ -5,6 +5,9 @@ using ChessVariantsLogic.Rules.Predicates;
 using ChessVariantsLogic.Rules.Predicates.ChessPredicates;
 
 namespace ChessVariantsLogic.Rules;
+/// <summary>
+/// Represents an event that can happen on the board. The Event will evaluate a predicate over the last boardTransition performed and then perform the internal set of actions.
+/// </summary>
 public class Event
 {
     private readonly IPredicate _predicate;
@@ -18,10 +21,20 @@ public class Event
         _relativeTo = relativeTo;
     }
 
+    /// <summary>
+    /// Evaluates if the internal predicate holds for the given BoardTransition.
+    /// </summary>
+    /// <returns>True if the predicate holds, otherwise false.</returns>
     public bool ShouldRun(BoardTransition lastTransition)
     {
         return _predicate.Evaluate(lastTransition);
     }
+
+    /// <summary>
+    /// Runs the event on the given <paramref name="moveWorker"/>. This does not take into account whether the event actually should be run.
+    /// </summary>
+    /// <param name="moveWorker">The MoveWorker we want to run the event on.</param>
+    /// <returns>True if the predicate holds, otherwise false.</returns>
 
     public GameEvent Run(MoveWorker moveWorker)
     {
@@ -29,19 +42,25 @@ public class Event
 
         var (from, to) = MoveWorker.ParseMove(lastMove.FromTo);
 
+        // Here we utilize the Move class to avoid code repetition.
+        // This is almost a bit of a hack though, so it might have to be changed in the future.
+
         string move = _relativeTo == RelativeTo.FROM ? from + from : to + to;
-        
+
         Move moveEvent = new Move(_actions, move, lastMove.PieceClassifier);
 
         return moveEvent.Perform(moveWorker);
     }
 
 
+    /// <summary>
+    /// Constructs a promotion event for all pawns of the given player
+    /// </summary>
     public static Event PromotionEvent(Player player, int boardHeight)
     {
         string pawnIdentifier = player == Player.White ? Constants.WhitePawnIdentifier : Constants.BlackPawnIdentifier;
         string queenIdentifier = player == Player.White ? Constants.WhiteQueenIdentifier : Constants.BlackQueenIdentifier;
-        int rank = player == Player.White ? 0 : (boardHeight-1);
+        int rank = player == Player.White ? (boardHeight) : 1;
 
         IPredicate pawnMoved = new PieceMoved(pawnIdentifier);
         IPredicate pawnAtRank = new PositionHasRank(new PositionRelative(0, 0), rank, RelativeTo.TO);
@@ -52,13 +71,17 @@ public class Event
     }
 
 
-    public static Event ExplosionEvent(Player player, IPosition pos)
+    /// <summary>
+    /// Constructs an event that removes a piece at the given <paramref name="position"/> when the given <paramref name="player"/> captures a piece.
+    /// If <paramref name="position"/> is relative, it will be calculated relative to the captured piece's position.
+    /// </summary>
+    public static Event ExplosionEvent(Player player, IPosition position)
     {
         string oppositePawnIdentifier = player == Player.White ? Constants.BlackPawnIdentifier : Constants.WhitePawnIdentifier;
         IPredicate pieceCaptured = player == Player.White ? new PieceCaptured("ANY_BLACK") : new PieceCaptured("ANY_WHITE");
-        IPredicate oppositePawnAt = new PieceAt(oppositePawnIdentifier, pos, BoardState.NEXT, RelativeTo.TO);
+        IPredicate oppositePawnAt = new PieceAt(oppositePawnIdentifier, position, BoardState.NEXT, RelativeTo.TO);
 
-        ISet<IAction> actions = new HashSet<IAction> { new ActionSetPiece(pos, Constants.UnoccupiedSquareIdentifier)};
+        ISet<IAction> actions = new HashSet<IAction> { new ActionSetPiece(position, Constants.UnoccupiedSquareIdentifier)};
 
         return new Event(pieceCaptured & !oppositePawnAt, actions, RelativeTo.TO);
     }

--- a/ChessVariantsLogic/Rules/IPosition.cs
+++ b/ChessVariantsLogic/Rules/IPosition.cs
@@ -19,7 +19,7 @@ public interface IPosition
     /// <param name="moveWorker">MoveWorker is needed to calculate the final position.</param>
     /// <param name="pivotPosition">The pivotPosition is needed when a relative position is to be calculated.</param>
     /// 
-    /// <returns>The calculated position as a string.</returns>
+    /// <returns>The calculated position as a tuple of ints.</returns>
     /// 
     public Tuple<int, int>? GetPositionTuple(MoveWorker moveWorker, string pivotPosition);
 }

--- a/ChessVariantsLogic/Rules/IPosition.cs
+++ b/ChessVariantsLogic/Rules/IPosition.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace ChessVariantsLogic.Rules;
+﻿namespace ChessVariantsLogic.Rules;
 /// <summary>
 /// Represents a position on the board that can be calculated at runtime.
 /// </summary>
@@ -19,4 +13,13 @@ public interface IPosition
     /// <returns>The calculated position as a string.</returns>
     /// 
     public string? GetPosition(MoveWorker moveWorker, string pivotPosition);
+    /// <summary>
+    /// Calculates the position and returns it as a tuple coordinate.
+    /// </summary>
+    /// <param name="moveWorker">MoveWorker is needed to calculate the final position.</param>
+    /// <param name="pivotPosition">The pivotPosition is needed when a relative position is to be calculated.</param>
+    /// 
+    /// <returns>The calculated position as a string.</returns>
+    /// 
+    public Tuple<int, int>? GetPositionTuple(MoveWorker moveWorker, string pivotPosition);
 }

--- a/ChessVariantsLogic/Rules/Moves/Actions/ActionDeletePiece.cs
+++ b/ChessVariantsLogic/Rules/Moves/Actions/ActionDeletePiece.cs
@@ -8,32 +8,10 @@ namespace ChessVariantsLogic.Rules.Moves.Actions;
 /// <summary>
 /// When performed this action will place an UnoccupiedSquareIdentifier at the target position.
 /// </summary>
-public class ActionDeletePiece : IAction
+public class ActionDeletePiece : ActionSetPiece
 {
-    private readonly IPosition _at;
-
-    public ActionDeletePiece(IPosition at)
+    public ActionDeletePiece(IPosition at) : base(at, Constants.UnoccupiedSquareIdentifier)
     {
-        _at = at;
     }
 
-
-    /// <summary>
-    /// Delete a piece on the board according to the internal _at position.
-    /// </summary>
-    /// <param name="moveWorker">MoveWorker that should perform the action.</param>
-    /// <param name="performingPiecePosition">This position is used to calculate the final position using the GetPosition method.</param>
-    /// 
-    /// <returns>A GameEvent that represents whether or not the action was successfully performed.</returns>
-    /// 
-    public GameEvent Perform(MoveWorker moveWorker, string performingPiecePosition)
-    {
-        string? finalPosition = _at.GetPosition(moveWorker, performingPiecePosition);
-        if (finalPosition == null) return GameEvent.InvalidMove;
-        bool performedSucessfully = moveWorker.Board.Insert(Constants.UnoccupiedSquareIdentifier, finalPosition);
-        if (performedSucessfully)
-            return GameEvent.MoveSucceeded;
-        else
-            return GameEvent.InvalidMove;
-    }
 }

--- a/ChessVariantsLogic/Rules/Moves/Actions/ActionSetPiece.cs
+++ b/ChessVariantsLogic/Rules/Moves/Actions/ActionSetPiece.cs
@@ -1,0 +1,33 @@
+﻿namespace ChessVariantsLogic.Rules.Moves.Actions;
+
+internal class ActionSetPiece : IAction
+{
+    private readonly IPosition _at;
+    private readonly string _pieceIdentifier;
+
+    public ActionSetPiece(IPosition at, string pieceIdentifier)
+    {
+        _at = at;
+        _pieceIdentifier = pieceIdentifier;
+    }
+
+
+    /// <summary>
+    /// Delete a piece on the board according to the internal _at position.
+    /// </summary>
+    /// <param name="moveWorker">MoveWorker that should perform the action.</param>
+    /// <param name="performingPiecePosition">This position is used to calculate the final position using the GetPosition method.</param>
+    /// 
+    /// <returns>A GameEvent that represents whether or not the action was successfully performed.</returns>
+    /// 
+    public GameEvent Perform(MoveWorker moveWorker, string performingPiecePosition)
+    {
+        string? finalPosition = _at.GetPosition(moveWorker, performingPiecePosition);
+        if (finalPosition == null) return GameEvent.InvalidMove;
+        bool performedSucessfully = moveWorker.Board.Insert(_pieceIdentifier, finalPosition);
+        if (performedSucessfully)
+            return GameEvent.MoveSucceeded;
+        else
+            return GameEvent.InvalidMove;
+    }
+}

--- a/ChessVariantsLogic/Rules/Moves/Actions/ActionSetPiece.cs
+++ b/ChessVariantsLogic/Rules/Moves/Actions/ActionSetPiece.cs
@@ -1,6 +1,9 @@
 ﻿namespace ChessVariantsLogic.Rules.Moves.Actions;
 
-internal class ActionSetPiece : IAction
+/// <summary>
+/// When performed this action will place the internal _pieceIdentifier at the target position.
+/// </summary>
+public class ActionSetPiece : IAction
 {
     private readonly IPosition _at;
     private readonly string _pieceIdentifier;
@@ -13,7 +16,7 @@ internal class ActionSetPiece : IAction
 
 
     /// <summary>
-    /// Delete a piece on the board according to the internal _at position.
+    /// Inserts a piece with the internal _pieceIdentifier on the board according to the internal _at position.
     /// </summary>
     /// <param name="moveWorker">MoveWorker that should perform the action.</param>
     /// <param name="performingPiecePosition">This position is used to calculate the final position using the GetPosition method.</param>

--- a/ChessVariantsLogic/Rules/PositionAbsolute.cs
+++ b/ChessVariantsLogic/Rules/PositionAbsolute.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace ChessVariantsLogic.Rules;
+﻿namespace ChessVariantsLogic.Rules;
 /// <summary>
 /// Represents an absolute position on the board.
 /// </summary>
@@ -28,5 +22,9 @@ public class PositionAbsolute : IPosition
     public string? GetPosition(MoveWorker moveWorker, string pivotPosition)
     {
         return _position;
+    }
+    public Tuple<int, int>? GetPositionTuple(MoveWorker moveWorker, string pivotPosition)
+    {
+        return moveWorker.Board.ParseCoordinate(_position);
     }
 }

--- a/ChessVariantsLogic/Rules/PositionAbsolute.cs
+++ b/ChessVariantsLogic/Rules/PositionAbsolute.cs
@@ -23,6 +23,15 @@ public class PositionAbsolute : IPosition
     {
         return _position;
     }
+
+    /// <summary>
+    /// Calculates the position and returns it as a tuple coordinate.
+    /// </summary>
+    /// <param name="moveWorker">Since absolute position is already given, this is not needed.</param>
+    /// <param name="pivotPosition">Since absolute position is already given, this is not needed.</param>
+    /// 
+    /// <returns>The calculated position as a tuple.</returns>
+    /// 
     public Tuple<int, int>? GetPositionTuple(MoveWorker moveWorker, string pivotPosition)
     {
         return moveWorker.Board.ParseCoordinate(_position);

--- a/ChessVariantsLogic/Rules/PositionRelative.cs
+++ b/ChessVariantsLogic/Rules/PositionRelative.cs
@@ -26,10 +26,25 @@ public class PositionRelative : IPosition
     /// 
     public string? GetPosition(MoveWorker moveWorker, string pivotPosition)
     {
-        Tuple<int, int>? pivotPostionTuple = moveWorker.Board.ParseCoordinate(pivotPosition);
-        if (pivotPostionTuple == null) return null;
-        Tuple<int, int> finalPosition = Tuple.Create(pivotPostionTuple.Item1 + _relativePosition.Item1, pivotPostionTuple.Item2 + _relativePosition.Item2);
+        Tuple<int, int> finalPosition = GetPositionTuple(moveWorker, pivotPosition);
+        if (finalPosition == null) return null;
         moveWorker.Board.IndexToCoor.TryGetValue(finalPosition, out string? finalPositionString);
         return finalPositionString;
+    }
+
+    /// <summary>
+    /// Calculates the position and returns it as a tuple coordinate.
+    /// </summary>
+    /// <param name="moveWorker">The MoveWorker containing the board with the position to calculate.</param>
+    /// <param name="pivotPosition">The final position will be calculated relative to the pivotPosition</param>
+    /// 
+    /// <returns>The calculated position as a string.</returns>
+    /// 
+
+    public Tuple<int, int>? GetPositionTuple(MoveWorker moveWorker, string pivotPosition)
+    {
+        Tuple<int, int>? pivotPositionTuple = moveWorker.Board.ParseCoordinate(pivotPosition);
+        if (pivotPositionTuple == null) return null;
+        return Tuple.Create(pivotPositionTuple.Item1 + _relativePosition.Item1, pivotPositionTuple.Item2 + _relativePosition.Item2);
     }
 }

--- a/ChessVariantsLogic/Rules/PositionRelative.cs
+++ b/ChessVariantsLogic/Rules/PositionRelative.cs
@@ -38,7 +38,7 @@ public class PositionRelative : IPosition
     /// <param name="moveWorker">The MoveWorker containing the board with the position to calculate.</param>
     /// <param name="pivotPosition">The final position will be calculated relative to the pivotPosition</param>
     /// 
-    /// <returns>The calculated position as a string.</returns>
+    /// <returns>The calculated position as a tuple.</returns>
     /// 
 
     public Tuple<int, int>? GetPositionTuple(MoveWorker moveWorker, string pivotPosition)

--- a/ChessVariantsLogic/Rules/Predicates/ChessPredicates/FirstMove.cs
+++ b/ChessVariantsLogic/Rules/Predicates/ChessPredicates/FirstMove.cs
@@ -6,7 +6,6 @@ using ChessVariantsLogic.Rules.Moves;
 /// </summary>
 public class FirstMove : IPredicate
 {
-
     public bool Evaluate(BoardTransition transition)
     {
         return transition.ThisState.Movelog.Count == 0;

--- a/ChessVariantsLogic/Rules/Predicates/ChessPredicates/HasMoved.cs
+++ b/ChessVariantsLogic/Rules/Predicates/ChessPredicates/HasMoved.cs
@@ -6,17 +6,21 @@ public class HasMoved : IPredicate
 {
     private readonly IPosition _position;
     private readonly BoardState _boardState;
+    private readonly RelativeTo _relativeTo;
 
-    public HasMoved(IPosition position, BoardState boardState = BoardState.THIS)
+    public HasMoved(IPosition position, BoardState boardState = BoardState.THIS, RelativeTo relativeTo = RelativeTo.FROM)
     {
         _position = position;
         _boardState = boardState;
+        _relativeTo = relativeTo;
     }
 
     public bool Evaluate(BoardTransition transition)
     {
         MoveWorker boardState = _boardState == BoardState.THIS ? transition.ThisState : transition.NextState;
-        string? coordinate = _position.GetPosition(boardState, transition.MoveFrom);
+        string relativePosition = _relativeTo == RelativeTo.FROM ? transition.MoveFrom : transition.MoveTo;
+
+        string? coordinate = _position.GetPosition(boardState, relativePosition);
         if (coordinate == null) return false;
         Tuple<int, int>? tupleCoordinate = boardState.Board.ParseCoordinate(coordinate);
         if (tupleCoordinate == null) return false;

--- a/ChessVariantsLogic/Rules/Predicates/ChessPredicates/LastMove.cs
+++ b/ChessVariantsLogic/Rules/Predicates/ChessPredicates/LastMove.cs
@@ -19,12 +19,15 @@ public class LastMove : IPredicate
     {
         Move? move = transition.ThisState.getLastMove();
         if (move == null) return false;
-        string lastMove = move.FromTo;
+        Tuple<string, string>? lastMove = MoveWorker.ParseMove(move.FromTo);
+        if(lastMove == null) return false;
         string? from = _compareFrom.GetPosition(transition.ThisState, transition.MoveFrom);
         string? to   = _compareTo.GetPosition(transition.ThisState, transition.MoveFrom);
 
-        if (from == null || to == null) return false;
+        if (from == null) return to == lastMove.Item2;
+        if (to == null) return from == lastMove.Item1;
+
         string compareMove = from + to;
-        return compareMove == lastMove;
+        return compareMove == (lastMove.Item1 + lastMove.Item2);
     }
 }

--- a/ChessVariantsLogic/Rules/Predicates/ChessPredicates/PieceAt.cs
+++ b/ChessVariantsLogic/Rules/Predicates/ChessPredicates/PieceAt.cs
@@ -7,13 +7,15 @@ public class PieceAt : IPredicate
     private readonly string _pieceIdentifier;
     private readonly IPosition _position;
     private readonly BoardState _boardState;
+    private readonly RelativeTo _relativeTo;
 
 
-    public PieceAt(string pieceIdentifier, IPosition position, BoardState boardState)
+    public PieceAt(string pieceIdentifier, IPosition position, BoardState boardState, RelativeTo relativeTo = RelativeTo.FROM)
     {
         _pieceIdentifier = pieceIdentifier;
         _position = position;
         _boardState = boardState;
+        _relativeTo = relativeTo;
     }
 
     /// <summary>
@@ -26,7 +28,7 @@ public class PieceAt : IPredicate
     {
         bool isThisBoardState = _boardState == BoardState.THIS;
         var board = isThisBoardState ? transition.ThisState : transition.NextState;
-        var relativePosition = transition.MoveFrom;
+        string relativePosition = _relativeTo == RelativeTo.FROM ? transition.MoveFrom : transition.MoveTo;
 
         string? finalPosition = _position.GetPosition(board, relativePosition);
         if (finalPosition == null) return false;

--- a/ChessVariantsLogic/Rules/Predicates/ChessPredicates/PositionHasRank.cs
+++ b/ChessVariantsLogic/Rules/Predicates/ChessPredicates/PositionHasRank.cs
@@ -31,10 +31,14 @@ public class PositionHasRank : IPredicate
         Tuple<int, int>? finalPosition = _position.GetPositionTuple(board, pivotPosition);
         if (finalPosition == null) return false;
 
-        return _rank == finalPosition.Item1;
+        return _rank == (board.Board.Rows - finalPosition.Item1);
     }   
 }
 
+
+/// <summary>
+/// An enum that determines whether predicates that evaluate positions should calculate their positions relative to the From or To variables of the supplied BoardTransition.
+/// </summary>
 public enum RelativeTo
 {
     FROM, TO

--- a/ChessVariantsLogic/Rules/Predicates/ChessPredicates/PositionHasRank.cs
+++ b/ChessVariantsLogic/Rules/Predicates/ChessPredicates/PositionHasRank.cs
@@ -1,0 +1,41 @@
+﻿
+namespace ChessVariantsLogic.Rules.Predicates.ChessPredicates;
+/// <summary>
+/// This predicate determines if a square has a certain rank.
+/// The target position can be calculated relatively or absolutely.
+/// </summary>
+public class PositionHasRank : IPredicate
+{
+    private readonly IPosition _position;
+    private readonly int _rank;
+    private readonly RelativeTo _relativeTo;
+
+
+    public PositionHasRank(IPosition position, int rank, RelativeTo relativeTo = RelativeTo.FROM)
+    {
+        _position = position;
+        _rank = rank;
+        _relativeTo = relativeTo;
+    }
+    /// <summary>
+    /// Evaluates to true/false if a square has a certain rank.
+    /// </summary>
+    /// <inheritdoc/>
+    /// <returns>true/false if a square has a certain rank.</returns>
+
+    public bool Evaluate(BoardTransition boardTransition)
+    {
+        var pivotPosition = _relativeTo == RelativeTo.FROM ? boardTransition.MoveFrom : boardTransition.MoveTo;
+        var board = boardTransition.ThisState;
+
+        Tuple<int, int>? finalPosition = _position.GetPositionTuple(board, pivotPosition);
+        if (finalPosition == null) return false;
+
+        return _rank == finalPosition.Item1;
+    }   
+}
+
+public enum RelativeTo
+{
+    FROM, TO
+}

--- a/ChessVariantsLogic/Rules/Predicates/ChessPredicates/SquareAttacked.cs
+++ b/ChessVariantsLogic/Rules/Predicates/ChessPredicates/SquareAttacked.cs
@@ -9,13 +9,15 @@ public class SquareAttacked : IPredicate
     private readonly IPosition _position;
     private readonly BoardState _boardState;
     private readonly Player _attacker;
+    private readonly RelativeTo _relativeTo;
 
 
-    public SquareAttacked(IPosition position, BoardState boardState, Player attacker)
+    public SquareAttacked(IPosition position, BoardState boardState, Player attacker, RelativeTo relativeTo = RelativeTo.FROM)
     {
         _position = position;
         _boardState = boardState;
         _attacker = attacker;
+        _relativeTo = relativeTo;
     }
     /// <summary>
     /// Evaluates to true/false if a square is attacked or not in either the current board state or the next, depending on what was specified at object-creation.
@@ -27,9 +29,9 @@ public class SquareAttacked : IPredicate
     {
         bool isThisBoardState = _boardState == BoardState.THIS;
         var board = isThisBoardState ? boardTransition.ThisState : boardTransition.NextState;
-        var pivotPosition = boardTransition.MoveFrom;
+        string relativePosition = _relativeTo == RelativeTo.FROM ? boardTransition.MoveFrom : boardTransition.MoveTo;
 
-        string? finalPosition = _position.GetPosition(board, pivotPosition);
+        string? finalPosition = _position.GetPosition(board, relativePosition);
         if (finalPosition == null) return false;
 
         return Utils.SquareAttacked(board, finalPosition, _attacker);

--- a/ChessVariantsLogic/Rules/RuleSet.cs
+++ b/ChessVariantsLogic/Rules/RuleSet.cs
@@ -15,12 +15,17 @@ public class RuleSet
     private readonly IPredicate _moveRule;
     private readonly IPredicate _winRule;
     private readonly ISet<MoveTemplate> _moveTemplates;
+    private readonly ISet<Event> _events;
 
-    public RuleSet(IPredicate moveRule, IPredicate winRule, ISet<MoveTemplate> moveTemplates)
+    public RuleSet(IPredicate moveRule, IPredicate winRule, ISet<MoveTemplate> moveTemplates, ISet<Event> events)
     {
         _moveRule = moveRule;
         _winRule = winRule;
         _moveTemplates = moveTemplates;
+        _events = events;
+    }
+    public RuleSet(IPredicate moveRule, IPredicate winRule, ISet<MoveTemplate> moveTemplates) : this(moveRule, winRule, moveTemplates, new HashSet<Event>())
+    {
     }
 
     public Dictionary<string, List<string>> GetLegalMoveDict(Player player, MoveWorker board)
@@ -72,7 +77,9 @@ public class RuleSet
             {
                 acceptedMoves.Add(move);
             }
+
         }
+
 
         foreach (var moveTemplate in _moveTemplates)
         {
@@ -80,6 +87,19 @@ public class RuleSet
         }
 
         return acceptedMoves;
+    }
+
+    public void RunEvents(BoardTransition lastTransition, MoveWorker moveWorker)
+    {
+        foreach(var e in _events) 
+        {
+            if(e.ShouldRun(lastTransition))
+            {
+                e.Run(moveWorker);
+            }
+
+        }
+
     }
 
     /// <summary>

--- a/ChessVariantsLogic/Rules/RuleSet.cs
+++ b/ChessVariantsLogic/Rules/RuleSet.cs
@@ -89,6 +89,12 @@ public class RuleSet
         return acceptedMoves;
     }
 
+    /// <summary>
+    /// Loops through all events. If the event's internal predicate holds for the <paramref name="lastTransition"/>, run the event.
+    /// </summary>
+    /// <param name="lastTransition">The last board transition</param>
+    /// <param name="moveWorker">The MoveWorker to run the event on</param>
+    /// <returns>All moves accepted by the game's moveRule</returns>
     public void RunEvents(BoardTransition lastTransition, MoveWorker moveWorker)
     {
         foreach(var e in _events) 


### PR DESCRIPTION
# Additions
In order to implement the event system the following things have been added:
- New Event class. The event contains a predicate and a list of actions. The ruleset now contains a set of events. Whenever a move is made we loop through all events and evaluate their predicate over the transition that was just made. If the predicate holds, the event's list of actions are performed on the board.
- A method that constructs a promotion Event for pawns. This Event will replace a pawn with a queen if it is on the last rank.
- A method that constructs an "explosion" Event, used in the implementation of atomic chess.
- An implementation of atomic chess in the GameFactory. This is just for fun, check out this link for more info: https://en.wikipedia.org/wiki/Atomic_chess
- PositionHasRank predicate with tests, used to determine if a position has a certain rank (needed for the promotion event).
- ActionSetPiece that sets the piece at the internal position to the internal pieceIdentifier.
# Changes
Some changes that have been made in this pull request:
- All predicates that evaluate positions now use a new enum called RelativeTo. It is used to determine whether relative positions should be calculated relative to the moveFrom or moveTo variable of the given BoardTransition when the predicate is evaluated.