### PR TITLE
Playing vs AI

### DIFF
--- a/ChessVariantsAPI/GameOrganization/ActiveGame.cs
+++ b/ChessVariantsAPI/GameOrganization/ActiveGame.cs
@@ -191,7 +191,7 @@ public class ActiveGame
         }
     }
 
-    private IEnumerable<Player> GetAvailableColors()
+    public IEnumerable<Player> GetAvailableColors()
     {
         var colors = new HashSet<Player>() { Player.White, Player.Black };
         colors.RemoveWhere(player => _playerDict.ContainsValue(player));

--- a/ChessVariantsLogic.Tests/ChessEngineTests.cs
+++ b/ChessVariantsLogic.Tests/ChessEngineTests.cs
@@ -1,8 +1,8 @@
 using ChessVariantsLogic.Rules.Moves;
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using Xunit;
+using ChessVariantsLogic.Engine;
 
 namespace ChessVariantsLogic.Tests;
 
@@ -32,7 +32,7 @@ public class ChessEngineTests : IDisposable
     {
         game.MoveWorker.InsertOnBoard(Piece.Rook(PieceClassifier.BLACK), "a3");
         string from = "a3";
-        Move bestMove = negaMax.findBestMove(2,game, Player.Black);
+        Move bestMove = negaMax.FindBestMove(2,game, Player.Black);
         Assert.Equal(from, bestMove.From);
     }
 
@@ -41,7 +41,7 @@ public class ChessEngineTests : IDisposable
     {
         game.MoveWorker.InsertOnBoard(Piece.Rook(PieceClassifier.BLACK), "a3");
         string moveFreePiece = "a3";
-        Move bestMove = negaMax.findBestMove(2,game, Player.White);
+        Move bestMove = negaMax.FindBestMove(2,game, Player.White);
         Assert.Equal(moveFreePiece, bestMove.To);
     }
 
@@ -52,7 +52,7 @@ public class ChessEngineTests : IDisposable
         game.MoveWorker.InsertOnBoard(Piece.Bishop(PieceClassifier.BLACK), "d6");
         game.MoveWorker.InsertOnBoard(Piece.Knight(PieceClassifier.WHITE), "b2");
         string moveFreePiece = "a3";
-        Move bestMove = negaMax.findBestMove(2,game, Player.White);
+        Move bestMove = negaMax.FindBestMove(2,game, Player.White);
         Assert.NotEqual(moveFreePiece, bestMove.To);
     }
 }

--- a/ChessVariantsLogic/Engine/AIFactory.cs
+++ b/ChessVariantsLogic/Engine/AIFactory.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ChessVariantsLogic.Engine;
+public static class AIFactory
+{
+    public static AIPlayer NegaMaxAI(Player player)
+    {
+        var pieceValues = new PieceValue(new List<Piece>());
+        var negaMax = new NegaMax(pieceValues);
+        return new AIPlayer(negaMax, player);
+    }
+}

--- a/ChessVariantsLogic/Engine/AIPlayer.cs
+++ b/ChessVariantsLogic/Engine/AIPlayer.cs
@@ -1,0 +1,19 @@
+﻿using ChessVariantsLogic.Rules.Moves;
+
+namespace ChessVariantsLogic.Engine;
+public class AIPlayer
+{
+    private readonly IMoveFinder _moveFinder;
+    public readonly Player PlayingAs;
+
+    public AIPlayer(IMoveFinder moveFinder, Player player)
+    {
+        _moveFinder = moveFinder;
+        PlayingAs = player;
+    }
+
+    public Move SearchMove(Game game, int depth=3)
+    {
+        return _moveFinder.FindBestMove(depth, game, PlayingAs);
+    }
+}

--- a/ChessVariantsLogic/Engine/IMoveFinder.cs
+++ b/ChessVariantsLogic/Engine/IMoveFinder.cs
@@ -1,0 +1,7 @@
+﻿using ChessVariantsLogic.Rules.Moves;
+
+namespace ChessVariantsLogic.Engine;
+public interface IMoveFinder
+{
+    public Move FindBestMove(int depth, Game game, Player player);
+}

--- a/ChessVariantsLogic/Engine/NegaMax.cs
+++ b/ChessVariantsLogic/Engine/NegaMax.cs
@@ -1,15 +1,8 @@
-namespace ChessVariantsLogic;
-
-using ChessVariantsLogic.Rules;
 using ChessVariantsLogic.Rules.Moves;
-using ChessVariantsLogic.Export;
-using ChessVariantsLogic;
 
+namespace ChessVariantsLogic.Engine;
 
-using System;
-using System.Collections.Generic;
-
-public class NegaMax
+public class NegaMax : IMoveFinder
 {
     private Move nextMove;
     private int whiteToMove = 1;
@@ -30,7 +23,7 @@ public class NegaMax
     /// <param name="game"> The game that is beeing played </param>
     /// <param name="player"> The player to move </param>
     /// <returns> The best move for the player </returns>
-    public Move findBestMove(int depth, Game game, Player player)
+    public Move FindBestMove(int depth, Game game, Player player)
     {
         IEnumerable<Move> validMoves;
         int turnMultiplier;
@@ -44,7 +37,7 @@ public class NegaMax
             validMoves = game.BlackRules.GetLegalMoves(game.MoveWorker, Player.Black).Values;
             turnMultiplier = blackToMove;
         }
-        negaMax(depth, turnMultiplier, depth, validMoves, game);
+        SearchNegaMax(depth, turnMultiplier, depth, validMoves, game);
 
         if(nextMove == null)
         {
@@ -55,11 +48,11 @@ public class NegaMax
 
     
 
-    private int negaMax(int currentDepth, int turnMultiplier, int maxDepth, IEnumerable<Move> validMoves, Game game)
+    private int SearchNegaMax(int currentDepth, int turnMultiplier, int maxDepth, IEnumerable<Move> validMoves, Game game)
     {
         if (currentDepth == 0)
         {
-            return turnMultiplier * scoreBoard(game.MoveWorker);
+            return turnMultiplier * ScoreBoard(game.MoveWorker);
         }
         int max = -1000;
         int score;
@@ -78,7 +71,7 @@ public class NegaMax
             {
                 nextValidMoves = game.BlackRules.GetLegalMoves(game.MoveWorker, Player.Black).Values;
             }
-            score = -negaMax(currentDepth - 1, -turnMultiplier, maxDepth, nextValidMoves, game);
+            score = -SearchNegaMax(currentDepth - 1, -turnMultiplier, maxDepth, nextValidMoves, game);
             if (score > max)
             {
                 max = score;
@@ -93,7 +86,7 @@ public class NegaMax
         return max;
     }
 
-    public int scoreBoard(MoveWorker moveWorker)
+    public int ScoreBoard(MoveWorker moveWorker)
     {
         int score = 0;
         for(int row = 0; row < moveWorker.Board.Rows; row++)
@@ -103,7 +96,7 @@ public class NegaMax
                 var piece = moveWorker.Board.GetPieceIdentifier(row,col);
                 if(piece != null)
                 {
-                    score += _pieceValue.getValue(piece);
+                    score += _pieceValue.GetValue(piece);
                 }
             }
         }

--- a/ChessVariantsLogic/Engine/PieceValue.cs
+++ b/ChessVariantsLogic/Engine/PieceValue.cs
@@ -1,5 +1,4 @@
-using ChessVariantsLogic;
-
+namespace ChessVariantsLogic.Engine;
 
 public class PieceValue
 {
@@ -8,9 +7,10 @@ public class PieceValue
 
     public PieceValue(List<Piece> pieces)
     {
-        pieceValue = initStandardPieceValues();
+        pieceValue = InitStandardPieceValues();
     }
-    public Dictionary<string, int> initStandardPieceValues()
+
+    public Dictionary<string, int> InitStandardPieceValues()
     {
         var dictionary = new Dictionary<string, int>();
 
@@ -33,7 +33,7 @@ public class PieceValue
         return dictionary;
     }
 
-    public int getValue(string piece)
+    public int GetValue(string piece)
     {
         return pieceValue[piece];
     }


### PR DESCRIPTION
This PR features functionality for playing vs the AI. Additionally it contains AI performance changes from @AxelSiwmark1 which clutter the request a bit. My idea is to rebase [my main changes](https://github.com/ChessVariants/ChessVariantsAPI/commit/465a127dde550a563f2d74a5de79626e78ab1515) on top of his branch when that has been merged. Still, if anyone wants to review this before then I suggest looking at the commit above.

## Meaningful changes
`Game` now has a private field called `_ai` which is of a new type called `AIPlayer`. The `AIPlayer` simply contains a `Player` enum (white / black) and a `MoveWorker` as that is needed by the AI to calculate its next move. Additionally the AI is created via an `AIFactory`, which at the moment only creates a AI for standard chess. This is easily changeable though as all it would need is a set of piece values.

The `Move()` method in `GameOrganizer` now yields GameEvents instead of simply returning them, and GameHub loops over these events and sends appropriate events to the frontend. This allows us to let the AI make all its moves (if it has multiple) before user input is needed again. If the process is slow it also communicates one move at a time, so if we're allowed multiple moves, the AI will calculate move one, then that move is sent to the FE, then move two is calculated and that is sent to the FE, and so on.