### PR TITLE
can now play vs ai

### DIFF
--- a/ChessVariantsAPI/GameOrganization/ActiveGame.cs
+++ b/ChessVariantsAPI/GameOrganization/ActiveGame.cs
@@ -191,7 +191,7 @@ public class ActiveGame
         }
     }
 
-    private IEnumerable<Player> GetAvailableColors()
+    public IEnumerable<Player> GetAvailableColors()
     {
         var colors = new HashSet<Player>() { Player.White, Player.Black };
         colors.RemoveWhere(player => _playerDict.ContainsValue(player));

--- a/ChessVariantsLogic.Tests/ChessEngineTests.cs
+++ b/ChessVariantsLogic.Tests/ChessEngineTests.cs
@@ -1,18 +1,18 @@
 using ChessVariantsLogic.Rules.Moves;
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using Xunit;
+using ChessVariantsLogic.Engine;
 
 namespace ChessVariantsLogic.Tests;
 
 public class ChessEngineTests : IDisposable
 {
-    private static List<Piece> pieces= new List<Piece>();
+    private static List<Piece> pieces = new List<Piece>();
     private Game game;
     private MoveWorker moveWorker;
     private static PieceValue pieceValue = new PieceValue(Piece.AllStandardPieces());
-    private NegaMax negaMax= new NegaMax(pieceValue);
+    private NegaMax negaMax = new NegaMax(pieceValue);
 
     public ChessEngineTests()
     {
@@ -32,7 +32,7 @@ public class ChessEngineTests : IDisposable
     {
         game.MoveWorker.InsertOnBoard(Piece.Rook(PieceClassifier.BLACK), "a3");
         string from = "a3";
-        Move bestMove = negaMax.FindBestMove(3,game, Player.Black);
+        Move bestMove = negaMax.FindBestMove(3, game, Player.Black);
         Assert.Equal(from, bestMove.From);
     }
 
@@ -41,37 +41,37 @@ public class ChessEngineTests : IDisposable
     {
         game.MoveWorker.InsertOnBoard(Piece.Rook(PieceClassifier.BLACK), "a3");
         string moveFreePiece = "a3";
-        Move bestMove = negaMax.FindBestMove(3,game, Player.White);
+        Move bestMove = negaMax.FindBestMove(3, game, Player.White);
         Assert.Equal(moveFreePiece, bestMove.To);
     }
 
-    [Fact ]
+    [Fact]
     public void NegaMaxDoesNotTakeDefendedPawnWithKnigt()
     {
         game.MoveWorker.InsertOnBoard(Piece.BlackPawn(), "a3");
         game.MoveWorker.InsertOnBoard(Piece.Bishop(PieceClassifier.BLACK), "d6");
         game.MoveWorker.InsertOnBoard(Piece.Knight(PieceClassifier.WHITE), "b2");
         string moveFreePiece = "a3";
-        Move bestMove = negaMax.FindBestMove(3,game, Player.White);
+        Move bestMove = negaMax.FindBestMove(3, game, Player.White);
         Assert.NotEqual(moveFreePiece, bestMove.To);
     }
 
-    [Fact ]
+    [Fact]
     public void NegaMaxCheckMate()
     {
         Move move1 = new Move("g2g4", Piece.WhitePawn());
         Move move2 = new Move("e7e5", Piece.BlackPawn());
         Move move3 = new Move("f2f3", Piece.WhitePawn());
-      
+
         game.MoveWorker.PerformMove(move1);
         game.MoveWorker.PerformMove(move2);
         game.MoveWorker.PerformMove(move3);
         string moveFreePiece = "h4";
-        Move bestMove = negaMax.FindBestMove(3,game, Player.Black);
+        Move bestMove = negaMax.FindBestMove(3, game, Player.Black);
         Assert.Equal(moveFreePiece, bestMove.To);
     }
 
-    [Fact ]
+    [Fact]
     public void NegaMaxDefendsCheckMate()
     {
         Move move1 = new Move("g2g4", Piece.WhitePawn());
@@ -82,7 +82,7 @@ public class ChessEngineTests : IDisposable
         game.MoveWorker.PerformMove(move2);
         game.MoveWorker.PerformMove(move3);
         string moveFreePiece = "d3";
-        Move bestMove = negaMax.FindBestMove(3,game, Player.White);
+        Move bestMove = negaMax.FindBestMove(3, game, Player.White);
         Assert.Equal(moveFreePiece, bestMove.To);
     }
 }

--- a/ChessVariantsLogic/Engine/AIFactory.cs
+++ b/ChessVariantsLogic/Engine/AIFactory.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ChessVariantsLogic.Engine;
+public static class AIFactory
+{
+    public static AIPlayer NegaMaxAI(Player player)
+    {
+        var pieceValues = new PieceValue(Piece.AllStandardPieces());
+        var negaMax = new NegaMax(pieceValues);
+        return new AIPlayer(negaMax, player);
+    }
+}

--- a/ChessVariantsLogic/Engine/AIPlayer.cs
+++ b/ChessVariantsLogic/Engine/AIPlayer.cs
@@ -1,0 +1,19 @@
+﻿using ChessVariantsLogic.Rules.Moves;
+
+namespace ChessVariantsLogic.Engine;
+public class AIPlayer
+{
+    private readonly IMoveFinder _moveFinder;
+    public readonly Player PlayingAs;
+
+    public AIPlayer(IMoveFinder moveFinder, Player player)
+    {
+        _moveFinder = moveFinder;
+        PlayingAs = player;
+    }
+
+    public Move SearchMove(Game game, int depth=3)
+    {
+        return _moveFinder.FindBestMove(depth, game, PlayingAs);
+    }
+}

--- a/ChessVariantsLogic/Engine/IMoveFinder.cs
+++ b/ChessVariantsLogic/Engine/IMoveFinder.cs
@@ -1,0 +1,7 @@
+﻿using ChessVariantsLogic.Rules.Moves;
+
+namespace ChessVariantsLogic.Engine;
+public interface IMoveFinder
+{
+    public Move FindBestMove(int depth, Game game, Player player);
+}

--- a/ChessVariantsLogic/Engine/NegaMax.cs
+++ b/ChessVariantsLogic/Engine/NegaMax.cs
@@ -1,15 +1,9 @@
-namespace ChessVariantsLogic;
-
 using ChessVariantsLogic.Rules;
 using ChessVariantsLogic.Rules.Moves;
-using ChessVariantsLogic.Export;
-using ChessVariantsLogic;
 
+namespace ChessVariantsLogic.Engine;
 
-using System;
-using System.Collections.Generic;
-
-public class NegaMax
+public class NegaMax : IMoveFinder
 {
     private Move _nextMove;
     private const int WhiteToMove = 1;
@@ -131,7 +125,7 @@ public class NegaMax
                 var piece = moveWorker.Board.GetPieceIdentifier(row, col);
                 if (piece != null)
                 {
-                    score += _pieceValue.getValue(piece);
+                    score += _pieceValue.GetValue(piece);
                 }
             }
         }
@@ -230,6 +224,6 @@ public class NegaMax
         _legalMovesLog.Push(legalMoves);
         return legalMoves;
     }
-
-
 }
+
+

--- a/ChessVariantsLogic/Engine/PieceValue.cs
+++ b/ChessVariantsLogic/Engine/PieceValue.cs
@@ -14,7 +14,8 @@ public class PieceValue
         pieces = Pieces;
         pieceValue = initPieces();
     }
-    public Dictionary<string, int> initStandardPieceValues()
+
+    public Dictionary<string, int> InitStandardPieceValues()
     {
         var dictionary = new Dictionary<string, int>();
 
@@ -45,19 +46,19 @@ public class PieceValue
 
         foreach (var piece in pieces)
         {
-            int pieceValue = calculateMovementValue(piece) + calculateCaptureValue(piece);
+            int pieceValue = CalculateMovementValue(piece) + CalculateCaptureValue(piece);
             dictionary.Add(piece.PieceIdentifier, pieceValue);
         }
 
         return dictionary;
     }
 
-    public int getValue(string piece)
+    public int GetValue(string piece)
     {
         return pieceValue[piece];
     }
 
-    private int calculateMovementValue(Piece piece)
+    private int CalculateMovementValue(Piece piece)
     {
         int value = 0;
         foreach (var pattern in piece.GetAllMovementPatterns())
@@ -78,7 +79,7 @@ public class PieceValue
         return value;
     }
 
-    private int calculateCaptureValue(Piece piece)
+    private int CalculateCaptureValue(Piece piece)
     {
         int value = 0;
         foreach (var pattern in piece.GetAllCapturePatterns())

--- a/ChessVariantsLogic/Game.cs
+++ b/ChessVariantsLogic/Game.cs
@@ -6,6 +6,7 @@ using ChessVariantsLogic.Export;
 
 using System;
 using System.Collections.Generic;
+using ChessVariantsLogic.Engine;
 
 public class Game {
 
@@ -15,6 +16,7 @@ public class Game {
     private readonly int _movesPerTurn;
     protected readonly RuleSet _whiteRules;
     protected readonly RuleSet _blackRules;
+    private AIPlayer? _ai;
     
 
     public MoveWorker MoveWorker
@@ -29,12 +31,13 @@ public class Game {
     {
         get { return _blackRules; }
     }
+    public bool ActiveAI => _ai != null;
 
     public IDictionary<string, Move> LegalMoves;
 
     
 
-    public Game(MoveWorker moveWorker, Player playerToStart, int movesPerTurn, RuleSet whiteRules, RuleSet blackRules)
+    public Game(MoveWorker moveWorker, Player playerToStart, int movesPerTurn, RuleSet whiteRules, RuleSet blackRules, AIPlayer? ai=null)
     {
         _moveWorker = moveWorker;
         PlayerTurn = playerToStart;
@@ -43,8 +46,6 @@ public class Game {
         _blackRules = blackRules;
         LegalMoves = GetRuleSetForPlayer(PlayerTurn).GetLegalMoves(_moveWorker, PlayerTurn);
     }
-    
-    
 
     /// <summary>
     /// Checks whether the given <paramref name="playerRequestingMove"/> is the one to move and if the move requested to be made is a legal move.
@@ -100,6 +101,27 @@ public class Game {
 
         return events;
     }
+
+    public void AssignAI(AIPlayer ai)
+    {
+        _ai = ai;
+    }
+
+    public ISet<GameEvent> MakeAIMove()
+    {
+        if (_ai == null)
+        {
+            throw new InvalidOperationException("Unable to make AI move as there is no AI assigned to this game.");
+        }
+        var bestMove = _ai.SearchMove(this);
+        return MakeMove(bestMove.FromTo, _ai.PlayingAs);
+    }
+
+    public bool AIShouldMakeMove()
+    {
+        return _ai != null && PlayerTurn == _ai.PlayingAs;
+    }
+
     public Dictionary<string, List<string>> GetLegalMoveDict()
     {
         var moveDict = new Dictionary<string, List<string>>();


### PR DESCRIPTION
This PR features functionality for playing vs the AI.

## Meaningful changes
`Game` now has a private field called `_ai` which is of a new type called `AIPlayer`. The `AIPlayer` simply contains a `Player` enum (white / black) and a `MoveWorker` as that is needed by the AI to calculate its next move. Additionally the AI is created via an `AIFactory`, which at the moment only creates a AI for standard chess. This is easily changeable though as all it would need is a set of piece values.

The `Move()` method in `GameOrganizer` now yields GameEvents instead of simply returning them, and GameHub loops over these events and sends appropriate events to the frontend. This allows us to let the AI make all its moves (if it has multiple) before user input is needed again. If the process is slow it also communicates one move at a time, so if we're allowed multiple moves, the AI will calculate move one, then that move is sent to the FE, then move two is calculated and that is sent to the FE, and so on.