### PR TITLE
User separated editors

### DIFF
--- a/ChessVariantsAPI/GameOrganization/EditorOrganizer.cs
+++ b/ChessVariantsAPI/GameOrganization/EditorOrganizer.cs
@@ -30,7 +30,7 @@ public class EditorOrganizer
         var editor = _activeEditors.GetValueOrDefault(editorId, null);
         if (editor != null)
         {
-            throw new OrganizerException($"The game (id: {editorId}) you're trying to create already exists");
+            throw new OrganizerException($"The editor (id: {editorId}) you're trying to create already exists");
         }
     }
 
@@ -39,7 +39,7 @@ public class EditorOrganizer
         var editor = _activeEditors.GetValueOrDefault(editorId, null);
         if (editor == null)
         {
-            throw new EditorNotFoundException($"No active game for gameId: {editorId}");
+            throw new EditorNotFoundException($"No active editor for editorId: {editorId}");
         }
         return editor;
     }

--- a/ChessVariantsAPI/GameOrganization/EditorOrganizer.cs
+++ b/ChessVariantsAPI/GameOrganization/EditorOrganizer.cs
@@ -1,3 +1,4 @@
+using ChessVariantsAPI.GameOrganization;
 using ChessVariantsLogic.Editor;
 using ChessVariantsLogic.Export;
 
@@ -8,55 +9,142 @@ namespace ChessVariantsAPI;
 /// </summary>
 public class EditorOrganizer
 {
-    private readonly PieceEditor _pieceEditor;
+
+    private readonly Dictionary<string, PieceEditor?> _activeEditors;
 
     public EditorOrganizer()
     {
-        _pieceEditor = new PieceEditor();
+        _activeEditors = new Dictionary<string, PieceEditor?>();
     }
 
-    public void RemoveAllMovementPatterns() { _pieceEditor.RemoveAllMovementPatterns(); }
-
-    public void ShowMovement(bool enable) { _pieceEditor.ShowMovement(enable); }
-
-    public void SetBoardSize(int rows, int cols) { _pieceEditor.UpdateBoardSize(rows, cols); }
-
-    public void SetActiveSquare(string square) { _pieceEditor.SetActiveSquare(square); }
-
-    public EditorState GetCurrentState() { return _pieceEditor.GetCurrentState(); }
-
-    public PatternState GetCurrentPatternState() { return _pieceEditor.GetCurrentPatternState(); }
-
-    public void AddMovementPattern(int xDir, int yDir, int minLength, int maxLength)
+    public PieceEditor CreateEditor(string editorId)
     {
-        _pieceEditor.AddMovementPattern(xDir, yDir, minLength, maxLength);
+        AssertEditorDoesNotExist(editorId);
+        var editor = new PieceEditor();
+        _activeEditors.Add(editorId, editor);
+        return editor;
     }
 
-    public void AddCapturePattern(int xDir, int yDir, int minLength, int maxLength)
+    private void AssertEditorDoesNotExist(string editorId)
     {
-        _pieceEditor.AddCapturePattern(xDir, yDir, minLength, maxLength);
+        var editor = _activeEditors.GetValueOrDefault(editorId, null);
+        if (editor != null)
+        {
+            throw new OrganizerException($"The game (id: {editorId}) you're trying to create already exists");
+        }
     }
 
-    public EditorEvent RemoveMovementPattern(int xDir, int yDir, int minLength, int maxLength)
+    private PieceEditor GetEditor(string editorId)
     {
-        return _pieceEditor.RemoveMovementPattern(xDir, yDir, minLength, maxLength);
+        var editor = _activeEditors.GetValueOrDefault(editorId, null);
+        if (editor == null)
+        {
+            throw new EditorNotFoundException($"No active game for gameId: {editorId}");
+        }
+        return editor;
     }
 
-    public EditorEvent BelongsToPlayer(string player) { return _pieceEditor.BelongsToPlayer(player); }
+    public void RemoveAllMovementPatterns(string editorId)
+    {
+        var editor = GetEditor(editorId);
+        editor.RemoveAllMovementPatterns();
+    }
 
-    public void SameMovementAndCapture(bool enable) { _pieceEditor.SetSameMovementAndCapturePattern(enable); }
+    public void ShowMovement(string editorId, bool enable)
+    {
+        var editor = GetEditor(editorId);
+        editor.ShowMovement(enable); 
+    }
 
-    public void CanBeCaptured(bool enable) { _pieceEditor.SetCanBeCaptured(enable); }
+    public void SetBoardSize(string editorId, int rows, int cols)
+    { 
+        var editor = GetEditor(editorId);
+        editor.UpdateBoardSize(rows, cols);
+    }
 
-    public void RepeatMovement(int repeat) { _pieceEditor.RepeatMovement(repeat); }
+    public void SetActiveSquare(string editorId, string square)
+    {
+        var editor = GetEditor(editorId);
+        editor.SetActiveSquare(square);
+    }
 
-    public void SetRoyal(bool enable) { _pieceEditor.SetRoyal(enable); }
+    public EditorState GetCurrentState(string editorId)
+    {
+        var editor = GetEditor(editorId);
+        return editor.GetCurrentState();
+    }
 
-    public EditorEvent Build() { return _pieceEditor.BuildPiece(); }
+    public PatternState GetCurrentPatternState(string editorId)
+    {
+        var editor = GetEditor(editorId);
+        return editor.GetCurrentPatternState();
+    }
 
-    public void Reset() { _pieceEditor.ResetPiece(); }
+    public void AddMovementPattern(string editorId, int xDir, int yDir, int minLength, int maxLength)
+    {
+        var editor = GetEditor(editorId);
+        editor.AddMovementPattern(xDir, yDir, minLength, maxLength);
+    }
 
-    public string GetStateAsJson() { return this._pieceEditor.ExportStateAsJson(); }
+    public void AddCapturePattern(string editorId, int xDir, int yDir, int minLength, int maxLength)
+    {
+        var editor = GetEditor(editorId);
+        editor.AddCapturePattern(xDir, yDir, minLength, maxLength);
+    }
+
+    public EditorEvent RemoveMovementPattern(string editorId, int xDir, int yDir, int minLength, int maxLength)
+    {
+        var editor = GetEditor(editorId);
+        return editor.RemoveMovementPattern(xDir, yDir, minLength, maxLength);
+    }
+
+    public EditorEvent BelongsToPlayer(string editorId, string player)
+    {
+        var editor = GetEditor(editorId);
+        return editor.BelongsToPlayer(player);
+    }
+
+    public void SameMovementAndCapture(string editorId, bool enable)
+    {
+        var editor = GetEditor(editorId);
+        editor.SetSameMovementAndCapturePattern(enable);
+    }
+
+    public void CanBeCaptured(string editorId, bool enable)
+    {
+        var editor = GetEditor(editorId);
+        editor.SetCanBeCaptured(enable);
+    }
+
+    public void RepeatMovement(string editorId, int repeat)
+    {
+        var editor = GetEditor(editorId);
+        editor.RepeatMovement(repeat);
+    }
+
+    public void SetRoyal(string editorId, bool enable)
+    {
+        var editor = GetEditor(editorId);
+        editor.SetRoyal(enable);
+    }
+
+    public EditorEvent Build(string editorId)
+    {
+        var editor = GetEditor(editorId);
+        return editor.BuildPiece();
+    }
+
+    public void Reset(string editorId)
+    {
+        var editor = GetEditor(editorId);
+        editor.ResetPiece();
+    }
+
+    public string GetStateAsJson(string editorId)
+    {
+        var editor = GetEditor(editorId);
+        return editor.ExportStateAsJson();
+    }
 
 
 }

--- a/ChessVariantsAPI/GameOrganization/EditorOrganizer.cs
+++ b/ChessVariantsAPI/GameOrganization/EditorOrganizer.cs
@@ -15,6 +15,8 @@ public class EditorOrganizer
         _pieceEditor = new PieceEditor();
     }
 
+    public void RemoveAllMovementPatterns() { _pieceEditor.RemoveAllMovementPatterns(); }
+
     public void ShowMovement(bool enable) { _pieceEditor.ShowMovement(enable); }
 
     public void SetBoardSize(int rows, int cols) { _pieceEditor.UpdateBoardSize(rows, cols); }

--- a/ChessVariantsAPI/GameOrganization/OrganizationExceptions.cs
+++ b/ChessVariantsAPI/GameOrganization/OrganizationExceptions.cs
@@ -23,7 +23,7 @@ public class GameNotFoundException : OrganizerException
 /// </summary>
 public class EditorNotFoundException : OrganizerException
 {
-    public EditorNotFoundException() : base("The game you were looking for does not exist") { }
+    public EditorNotFoundException() : base("The editor you were looking for does not exist") { }
     public EditorNotFoundException(string message) : base(message) { }
 }
 

--- a/ChessVariantsAPI/GameOrganization/OrganizationExceptions.cs
+++ b/ChessVariantsAPI/GameOrganization/OrganizationExceptions.cs
@@ -19,6 +19,15 @@ public class GameNotFoundException : OrganizerException
 }
 
 /// <summary>
+/// Exception for when an editor is not found amongst the active games.
+/// </summary>
+public class EditorNotFoundException : OrganizerException
+{
+    public EditorNotFoundException() : base("The game you were looking for does not exist") { }
+    public EditorNotFoundException(string message) : base(message) { }
+}
+
+/// <summary>
 /// Exception for when a player is not found.
 /// </summary>
 public class PlayerNotFoundException : OrganizerException

--- a/ChessVariantsAPI/Hubs/EditorHub.cs
+++ b/ChessVariantsAPI/Hubs/EditorHub.cs
@@ -1,8 +1,5 @@
 using Microsoft.AspNetCore.SignalR;
 using ChessVariantsLogic.Export;
-using ChessVariantsAPI.Hubs.DTOs;
-using static ChessVariantsAPI.Hubs.GameHub;
-using ChessVariantsAPI.GameOrganization;
 
 namespace ChessVariantsAPI.Hubs;
 
@@ -10,14 +7,12 @@ public class EditorHub : Hub
 {
 
     private readonly EditorOrganizer _organizer;
-    private readonly GroupOrganizer _groupOrganizer;
     readonly protected ILogger _logger;
 
-    public EditorHub(EditorOrganizer organizer, ILogger<EditorHub> logger, GroupOrganizer groupOrganizer)
+    public EditorHub(EditorOrganizer organizer, ILogger<EditorHub> logger)
     {
         _organizer = organizer;
         _logger = logger;
-        _groupOrganizer = groupOrganizer;
     }
 
     public async Task CreateEditor(string editorId)
@@ -25,17 +20,6 @@ public class EditorHub : Hub
         _organizer.CreateEditor(editorId);
         await UpdateEditorState(editorId);
         await UpdatePatternState(editorId);
-    }
-
-    private string GetUsername()
-    {
-        var username = Context.GetUsername(); // returns null for some reason.
-        if (username == null)
-        {
-            _logger.LogInformation("Unauthenticated request by connection: {connId}", Context.ConnectionId);
-            throw new AuthenticationError(Events.Errors.UnauthenticatedRequest);
-        }
-        return username;
     }
 
     public EditorState RequestState(string editorId) { return _organizer.GetCurrentState(editorId); }

--- a/ChessVariantsAPI/Hubs/EditorHub.cs
+++ b/ChessVariantsAPI/Hubs/EditorHub.cs
@@ -1,5 +1,8 @@
 using Microsoft.AspNetCore.SignalR;
 using ChessVariantsLogic.Export;
+using ChessVariantsAPI.Hubs.DTOs;
+using static ChessVariantsAPI.Hubs.GameHub;
+using ChessVariantsAPI.GameOrganization;
 
 namespace ChessVariantsAPI.Hubs;
 
@@ -7,104 +10,125 @@ public class EditorHub : Hub
 {
 
     private readonly EditorOrganizer _organizer;
+    private readonly GroupOrganizer _groupOrganizer;
+    readonly protected ILogger _logger;
 
-    public EditorHub(EditorOrganizer organizer)
+    public EditorHub(EditorOrganizer organizer, ILogger<EditorHub> logger, GroupOrganizer groupOrganizer)
     {
-        this._organizer = organizer;
+        _organizer = organizer;
+        _logger = logger;
+        _groupOrganizer = groupOrganizer;
     }
 
-    public EditorState RequestState() { return _organizer.GetCurrentState(); }
+    public async Task CreateEditor(string editorId)
+    { 
+        _organizer.CreateEditor(editorId);
+        await UpdateEditorState(editorId);
+        await UpdatePatternState(editorId);
+    }
 
-    public PatternState RequestPatternState() { return _organizer.GetCurrentPatternState(); }
-
-    public async Task UpdatePatternState()
+    private string GetUsername()
     {
-        var patternState = _organizer.GetCurrentPatternState();
+        var username = Context.GetUsername(); // returns null for some reason.
+        if (username == null)
+        {
+            _logger.LogInformation("Unauthenticated request by connection: {connId}", Context.ConnectionId);
+            throw new AuthenticationError(Events.Errors.UnauthenticatedRequest);
+        }
+        return username;
+    }
+
+    public EditorState RequestState(string editorId) { return _organizer.GetCurrentState(editorId); }
+    public PatternState RequestPatternState(string editorId) { return _organizer.GetCurrentPatternState(editorId); }
+
+    public async Task UpdatePatternState(string editorId)
+    {
+        var patternState = _organizer.GetCurrentPatternState(editorId);
         await Clients.Caller.SendUpdatedPatternState(patternState);
     }
 
-    public async Task UpdateEditorState()
+    public async Task UpdateEditorState(string editorId)
     {
-        var state = _organizer.GetCurrentState();
+        var state = _organizer.GetCurrentState(editorId);
         await Clients.Caller.SendUpdatedEditorState(state);
     }
 
-    public async Task ActivateSquare(string square)
+    public async Task ActivateSquare(string editorId, string square)
     {
-        _organizer.SetActiveSquare(square);
-        await UpdateEditorState();
+        _organizer.SetActiveSquare(editorId, square);
+        await UpdateEditorState(editorId);
     }
 
-    public async Task AddMovementPattern(int xDir, int yDir, int minLength, int maxLength)
+    public async Task AddMovementPattern(string editorId, int xDir, int yDir, int minLength, int maxLength)
     {
-        _organizer.AddMovementPattern(xDir, yDir, minLength, maxLength);
-        await UpdatePatternState();
-        await UpdateEditorState();
+        _organizer.AddMovementPattern(editorId, xDir, yDir, minLength, maxLength);
+        await UpdatePatternState(editorId);
+        await UpdateEditorState(editorId);
     }
 
-    public async Task RemoveMovementPattern(int xDir, int yDir, int minLength, int maxLength)
+    public async Task RemoveMovementPattern(string editorId, int xDir, int yDir, int minLength, int maxLength)
     {
-        _organizer.RemoveMovementPattern(xDir, yDir, minLength, maxLength);
-        await UpdatePatternState();
-        await UpdateEditorState();
+        _organizer.RemoveMovementPattern(editorId, xDir, yDir, minLength, maxLength);
+        await UpdatePatternState(editorId);
+        await UpdateEditorState(editorId);
     }
 
-    public async Task AddCapturePattern(int xDir, int yDir, int minLength, int maxLength)
+    public async Task AddCapturePattern(string editorId, int xDir, int yDir, int minLength, int maxLength)
     {
-        _organizer.AddCapturePattern(xDir, yDir, minLength, maxLength);
-        await UpdatePatternState();
-        await UpdateEditorState();
+        _organizer.AddCapturePattern(editorId, xDir, yDir, minLength, maxLength);
+        await UpdatePatternState(editorId);
+        await UpdateEditorState(editorId);
     }
 
-    public async Task UpdateBoardSize(int rows, int cols)
+    public async Task UpdateBoardSize(string editorId, int rows, int cols)
     {
-        _organizer.SetBoardSize(rows, cols);
-        await UpdateEditorState();
+        _organizer.SetBoardSize(editorId, rows, cols);
+        await UpdateEditorState(editorId);
     }
 
-    public async Task SetCaptureSameAsMovement(bool enable)
+    public async Task SetCaptureSameAsMovement(string editorId, bool enable)
     {
-        _organizer.SameMovementAndCapture(enable);
-        await UpdateEditorState();
+        _organizer.SameMovementAndCapture(editorId, enable);
+        await UpdateEditorState(editorId);
     }
     
-    public async Task ShowMovement(bool enable)
+    public async Task ShowMovement(string editorId, bool enable)
     {
-        _organizer.ShowMovement(enable);
-        await UpdatePatternState();
-        await UpdateEditorState();
+        _organizer.ShowMovement(editorId, enable);
+        await UpdatePatternState(editorId);
+        await UpdateEditorState(editorId);
     }
 
-    public async Task PieceCanBeCaptured(bool enable)
+    public async Task PieceCanBeCaptured(string editorId, bool enable)
     {
-        _organizer.CanBeCaptured(enable);
-        await UpdateEditorState();
+        _organizer.CanBeCaptured(editorId, enable);
+        await UpdateEditorState(editorId);
     }
 
-    public async Task BelongsToPlayer(string player)
+    public async Task BelongsToPlayer(string editorId, string player)
     {
-        _organizer.BelongsToPlayer(player);
-        await UpdateEditorState();
+        _organizer.BelongsToPlayer(editorId, player);
+        await UpdateEditorState(editorId);
     }
 
-    public async Task AmountRepeat(int repeat)
+    public async Task AmountRepeat(string editorId, int repeat)
     {
-        _organizer.RepeatMovement(repeat);
-        await UpdateEditorState();
+        _organizer.RepeatMovement(editorId, repeat);
+        await UpdateEditorState(editorId);
     }
 
-    public async Task ClearMovementPatterns()
+    public async Task ClearMovementPatterns(string editorId)
     {
-        _organizer.RemoveAllMovementPatterns();
-        await UpdatePatternState();
-        await UpdateEditorState();
+        _organizer.RemoveAllMovementPatterns(editorId);
+        await UpdatePatternState(editorId);
+        await UpdateEditorState(editorId);
     }
 
-    public async Task ResetPiece()
+    public async Task ResetPiece(string editorId)
     {
-        _organizer.Reset();
-        await UpdatePatternState();
-        await UpdateEditorState();
+        _organizer.Reset(editorId);
+        await UpdatePatternState(editorId);
+        await UpdateEditorState(editorId);
     }
 
 }

--- a/ChessVariantsAPI/Hubs/EditorHub.cs
+++ b/ChessVariantsAPI/Hubs/EditorHub.cs
@@ -93,5 +93,18 @@ public class EditorHub : Hub
         await UpdateEditorState();
     }
 
+    public async Task ClearMovementPatterns()
+    {
+        _organizer.RemoveAllMovementPatterns();
+        await UpdatePatternState();
+        await UpdateEditorState();
+    }
+
+    public async Task ResetPiece()
+    {
+        _organizer.Reset();
+        await UpdatePatternState();
+        await UpdateEditorState();
+    }
 
 }

--- a/ChessVariantsAPI/Hubs/GameHub.cs
+++ b/ChessVariantsAPI/Hubs/GameHub.cs
@@ -328,7 +328,7 @@ public class GameHub : Hub
     }
 
 
-    public class AuthenticationError : Exception
+    private class AuthenticationError : Exception
     {
         public string ErrorType { get; }
         public AuthenticationError(string errorType)

--- a/ChessVariantsAPI/Hubs/GameHub.cs
+++ b/ChessVariantsAPI/Hubs/GameHub.cs
@@ -328,7 +328,7 @@ public class GameHub : Hub
     }
 
 
-    private class AuthenticationError : Exception
+    public class AuthenticationError : Exception
     {
         public string ErrorType { get; }
         public AuthenticationError(string errorType)

--- a/ChessVariantsLogic/Editor/PieceEditor.cs
+++ b/ChessVariantsLogic/Editor/PieceEditor.cs
@@ -155,6 +155,14 @@ public class PieceEditor
 
     }
 
+    public void RemoveAllMovementPatterns()
+    { 
+        if(_showMovement)
+            _builder.RemoveAllMovementPatterns();
+        else
+            _builder.RemoveAllCapturePatterns();
+    }
+
     /// <summary>
     /// Sets the player that the piece should belong to, i.e. "white", "black", or "shared".
     /// </summary>

--- a/ChessVariantsLogic/Piece/PieceBuilder.cs
+++ b/ChessVariantsLogic/Piece/PieceBuilder.cs
@@ -200,6 +200,10 @@ public class PieceBuilder
         return this.movementPattern.RemovePattern(pattern);
     }
 
+    public void RemoveAllMovementPatterns() { movementPattern = new MovementPattern(); }
+
+    public void RemoveAllCapturePatterns() { capturePattern = new MovementPattern(); }
+
     /// <summary>
     /// Adds a regular pattern to the allowed capture patterns. 
     /// </summary>


### PR DESCRIPTION
This is a small PR containing the logic that allows different users to have their own editor, a functionality that I had previously missed. It works similarly to `GameOrganizer` in that it maps an editorID to a specific pieceEditor (@sjohan99 I found some proper use of `EditorOrganizer` ;) ). Moreover, some additional small functionality has been added. There is a corresponding [PR](https://github.com/ChessVariants/chess-variants-frontend/pull/9) on the frontend.

Happy reviewing!