### PR TITLE
Fixed an issue with MoveTemplates and the predicate MoveWas

### DIFF
--- a/ChessVariantsLogic/Rules/Moves/Actions/Action.cs
+++ b/ChessVariantsLogic/Rules/Moves/Actions/Action.cs
@@ -17,6 +17,10 @@ public abstract class Action
         return Utils.IsOfType(_capturedPiece, pieceIdentifier);
     }
 
+    public void ClearAction()
+    {
+        _capturedPiece = null;
+    }
 
     /// <summary>
     /// Performs an action on the given moveWorker according to implementation.

--- a/ChessVariantsLogic/Rules/Moves/MoveTemplate.cs
+++ b/ChessVariantsLogic/Rules/Moves/MoveTemplate.cs
@@ -41,6 +41,7 @@ public class MoveTemplate
         List<string> positions = (List<string>)Utils.FindPiecesOfType(moveWorker, _pieceIdentifier);
         PieceClassifier pieceClassifier = moveWorker.GetPieceClassifier(_pieceIdentifier);
         ISet<Move> moves = new HashSet<Move>();
+        ClearActions();
 
         foreach (string from in positions)
         {
@@ -69,6 +70,7 @@ public class MoveTemplate
     {
         List<string> positions = (List<string>)Utils.FindPiecesOfType(moveWorker, _pieceIdentifier);
         PieceClassifier pieceClassifier = moveWorker.GetPieceClassifier(_pieceIdentifier);
+        ClearActions();
 
         foreach (string from in positions)
         {
@@ -85,6 +87,14 @@ public class MoveTemplate
         }
 
         return false;
+    }
+
+    private void ClearActions()
+    {
+        foreach(Action a in _actions)
+        {
+            a.ClearAction();
+        }
     }
 
     public static MoveTemplate CastleMove(Player player, bool kingSide, bool kingCanMoveThroughChecks)

--- a/ChessVariantsLogic/Rules/Predicates/ChessPredicates/MovePredicates/MoveWas.cs
+++ b/ChessVariantsLogic/Rules/Predicates/ChessPredicates/MovePredicates/MoveWas.cs
@@ -26,8 +26,8 @@ public class MoveWas : MovePredicate
 
         var moveCoordinates = MoveWorker.ParseMove(move.FromTo);
         if (moveCoordinates == null) return false;
-        string? from = _compareFrom.GetPosition(transition.ThisState, transition.MoveFrom);
-        string? to = _compareTo.GetPosition(transition.ThisState, transition.MoveFrom);
+        string? from = _compareFrom.GetPosition(transition.ThisState, transition.MoveFromTo);
+        string? to = _compareTo.GetPosition(transition.ThisState, transition.MoveFromTo);
 
         if (from == null) return to == moveCoordinates.Item2;
         if (to == null) return from == moveCoordinates.Item1;


### PR DESCRIPTION
Fixed a bug that we discussed during todays meeting. Playing antichess should now work as before, with en passant and pawn double moves.