### PR TITLE
Save piece to database

### DIFF
--- a/ChessVariantsAPI.Tests/ObjectTranslationTests/PieceTranslatorTests.cs
+++ b/ChessVariantsAPI.Tests/ObjectTranslationTests/PieceTranslatorTests.cs
@@ -1,0 +1,14 @@
+﻿using ChessVariantsAPI.ObjectTranslations;
+using Xunit;
+
+namespace ChessVariantsAPI.Tests.ObjectTranslationTests;
+public class PieceTranslatorTests
+{
+    [Fact]
+    public void CreatePieceModel_ShouldNotThrowException()
+    {
+        var p = ChessVariantsLogic.Piece.BlackPawn();
+        var exception = Record.Exception(() => PieceTranslator.CreatePieceModel(p, "test-piece", "me", "pawn.png"));
+        Assert.Null(exception);
+    }
+}

--- a/ChessVariantsAPI/Controllers/PieceController.cs
+++ b/ChessVariantsAPI/Controllers/PieceController.cs
@@ -1,0 +1,31 @@
+﻿using ChessVariantsAPI.ObjectTranslations;
+using ChessVariantsLogic;
+using DataAccess.MongoDB;
+using Microsoft.AspNetCore.Mvc;
+
+namespace ChessVariantsAPI.Controllers;
+[Route("api/[controller]")]
+[ApiController]
+public class PieceController : GenericController
+{
+    public PieceController(DatabaseService databaseService, ILogger<UsersController> logger) : base(databaseService, logger)
+    {
+    }
+
+    [HttpGet]
+    public async Task<IActionResult> GetPiece()
+    {
+        var logicPiece = Piece.Queen(PieceClassifier.WHITE);
+        var modelPiece = PieceTranslator.CreatePieceModel(logicPiece, "test-queen", "me", "images/queen.svg");
+        await _db.Pieces.CreateAsync(modelPiece);
+        return Ok();
+    }
+
+    [HttpPost]
+    public async Task<IActionResult> SavePiece(DataAccess.MongoDB.Models.Piece piece)
+    {
+        piece.Id = null;
+        await _db.Pieces.CreateAsync(piece);
+        return Ok();
+    }
+}

--- a/ChessVariantsAPI/ObjectTranslations/PieceTranslator.cs
+++ b/ChessVariantsAPI/ObjectTranslations/PieceTranslator.cs
@@ -1,0 +1,38 @@
+﻿using ChessVariantsLogic;
+using DataAccess.MongoDB.Models;
+
+namespace ChessVariantsAPI.ObjectTranslations;
+
+public static class PieceTranslator
+{
+    public static DataAccess.MongoDB.Models.Piece CreatePieceModel(ChessVariantsLogic.Piece piece, string name, string creator, string imagePath)
+    {
+        return new DataAccess.MongoDB.Models.Piece
+        {
+            Name = name,
+            Creator = creator,
+            Repeat = piece.Repeat,
+            CanBeCaptured = piece.CanBeCaptured,
+            ImagePath = imagePath,
+            Movement = TranslatePatterns(piece.GetAllMovementPatterns()),
+            Captures = TranslatePatterns(piece.GetAllCapturePatterns()),
+        };
+    }
+
+    private static List<MovePattern> TranslatePatterns(IEnumerable<Pattern> logicPatterns)
+    {
+        var ModelMovePatterns = new List<MovePattern>();
+        foreach (var pattern in logicPatterns)
+        {
+            MovePattern m = new()
+            {
+                XDir = pattern.XDir,
+                YDir = pattern.YDir,
+                MaxLength = pattern.MaxLength,
+                MinLength = pattern.MinLength
+            };
+            ModelMovePatterns.Add(m);
+        }
+        return ModelMovePatterns;
+    }
+}

--- a/ChessVariantsAPI/ObjectTranslations/PieceTranslator.cs
+++ b/ChessVariantsAPI/ObjectTranslations/PieceTranslator.cs
@@ -13,6 +13,7 @@ public static class PieceTranslator
             Creator = creator,
             Repeat = piece.Repeat,
             CanBeCaptured = piece.CanBeCaptured,
+            CanBePromotedTo = piece.CanBePromotedTo,
             ImagePath = imagePath,
             Movement = TranslatePatterns(piece.GetAllMovementPatterns()),
             Captures = TranslatePatterns(piece.GetAllCapturePatterns()),

--- a/ChessVariantsAPI/Properties/launchSettings.json
+++ b/ChessVariantsAPI/Properties/launchSettings.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "$schema": "https://json.schemastore.org/launchsettings.json",
   "iisSettings": {
     "windowsAuthentication": false,
@@ -11,7 +11,6 @@
   "profiles": {
     "ChessVariantsAPI": {
       "commandName": "Project",
-      "dotnetRunMessages": true,
       "launchBrowser": true,
       "launchUrl": "swagger",
       "applicationUrl": "https://localhost:7081;http://localhost:5081",

--- a/ChessVariantsLogic.Tests/ChessboardTests.cs
+++ b/ChessVariantsLogic.Tests/ChessboardTests.cs
@@ -267,7 +267,7 @@ public class ChessboardTests : IDisposable
 
         };
         var mp = new MovementPattern(patterns);
-        Piece piece = new Piece(mp, mp, false, PieceClassifier.WHITE, customPieceNotation);
+        Piece piece = new Piece(mp, mp, PieceClassifier.WHITE, customPieceNotation);
 
         this.moveWorker.InsertOnBoard(piece, "c4");
 
@@ -301,7 +301,7 @@ public class ChessboardTests : IDisposable
             new RegularPattern(Constants.West,  1, 8),
         };
         var mp = new MovementPattern(patterns);
-        Piece piece1 = new Piece(mp, mp, false, PieceClassifier.WHITE, 1, customPieceNotation, true);
+        Piece piece1 = new Piece(mp, mp, PieceClassifier.WHITE, 1, customPieceNotation, true, true);
         var piece2 = Piece.BlackPawn();
 
         this.moveWorker.InsertOnBoard(piece1, "h4");
@@ -394,7 +394,7 @@ public class ChessboardTests : IDisposable
 
         var mp = new MovementPattern(patterns);
         var cp = new MovementPattern(capturePatterns);
-        Piece piece = new Piece(mp, cp, false, PieceClassifier.WHITE, customPieceNotation);
+        Piece piece = new Piece(mp, cp, PieceClassifier.WHITE, customPieceNotation);
 
         this.moveWorker.InsertOnBoard(piece, "h1");
         this.moveWorker.Move("h2h3");
@@ -431,7 +431,7 @@ public class ChessboardTests : IDisposable
 
         var mp = new MovementPattern(patterns);
         var cp = new MovementPattern(capturePattern);
-        Piece piece = new Piece(mp, cp, false, PieceClassifier.WHITE, customPieceNotation);
+        Piece piece = new Piece(mp, cp, PieceClassifier.WHITE, customPieceNotation);
 
         this.moveWorker.InsertOnBoard(piece, "h1");
         
@@ -470,7 +470,7 @@ public class ChessboardTests : IDisposable
         
         var mp = new MovementPattern(patterns);
         var cp = new  MovementPattern(capturePatterns);
-        Piece piece1 = new Piece(mp, cp, false, PieceClassifier.WHITE , customPieceNotation);
+        Piece piece1 = new Piece(mp, cp, PieceClassifier.WHITE , customPieceNotation);
         Piece piece2 = Piece.BlackPawn();
         
         this.moveWorker.InsertOnBoard(piece1, "d4");

--- a/ChessVariantsLogic.Tests/PieceExporterTests.cs
+++ b/ChessVariantsLogic.Tests/PieceExporterTests.cs
@@ -54,7 +54,7 @@ public class PieceExporterTests
         };
         var mp = new MovementPattern(patterns);
 
-        var expected = new Piece(mp, mp, false, PieceClassifier.WHITE, 1, "ca", true);
+        var expected = new Piece(mp, mp, PieceClassifier.WHITE, 1, "ca", true, true);
         string jsonPiece = expected.ExportAsJson();
         var actual = PieceBuilder.ParseJson(jsonPiece);
 
@@ -76,7 +76,7 @@ public class PieceExporterTests
         };
         var cp = new MovementPattern(captures);
 
-        var expected = new Piece(mp, cp, false, PieceClassifier.WHITE, 1, "ca", true);
+        var expected = new Piece(mp, cp, PieceClassifier.WHITE, 1, "ca", true, true);
         string jsonPiece = expected.ExportAsJson();
         var actual = PieceBuilder.ParseJson(jsonPiece);
 

--- a/ChessVariantsLogic/Piece/Piece.cs
+++ b/ChessVariantsLogic/Piece/Piece.cs
@@ -11,7 +11,6 @@ public class Piece
 
     private MovementPattern movementPattern { get; }
     private MovementPattern capturePattern { get; }
-    public bool Royal { get; }
 
     public PieceClassifier PieceClassifier { get; }
 
@@ -20,6 +19,8 @@ public class Piece
     public string PieceIdentifier { get; }
 
     public bool CanBeCaptured { get; }
+
+    public bool CanBePromotedTo { get; }
 
     /// <summary>
     /// Constructor for a new Piece.
@@ -30,14 +31,14 @@ public class Piece
     /// <param name="pc">is the player the piece belongs to</param>
     /// <param name="repeat">is the amount of times the movement pattern can be repeated on the same turn</param>
     /// <param name="pieceIdentifier">is the unique string representation of the piece</param>
-    public Piece(MovementPattern movementPattern, MovementPattern capturePattern, bool royal, PieceClassifier pc, int repeat, string pieceIdentifier, bool canBeCaptured)
+    public Piece(MovementPattern movementPattern, MovementPattern capturePattern, PieceClassifier pc, int repeat, string pieceIdentifier, bool canBeCaptured, bool canBePromotedTo)
     {
         this.movementPattern = movementPattern;
         this.capturePattern = capturePattern;
-        this.Royal = royal;
         this.PieceClassifier = pc;
         this.PieceIdentifier = pieceIdentifier;
         this.CanBeCaptured = canBeCaptured;
+        this.CanBePromotedTo = canBePromotedTo;
 
         //This might not be optimal since it doesn't notify the user that the value is not what it was set to.
         if(repeat < 0)
@@ -48,8 +49,8 @@ public class Piece
             this.Repeat = repeat;
     }
 
-    public Piece(MovementPattern movementPattern, MovementPattern capturePattern, bool royal, PieceClassifier pc, string pieceIdentifier, bool canBeCaptured = true)
-    : this(movementPattern, capturePattern, royal, pc, 0, pieceIdentifier, canBeCaptured) {}
+    public Piece(MovementPattern movementPattern, MovementPattern capturePattern, PieceClassifier pc, string pieceIdentifier, bool canBeCaptured = true, bool canBePromotedTo = true)
+    : this(movementPattern, capturePattern, pc, 0, pieceIdentifier, canBeCaptured, canBePromotedTo) {}
 
 
 #endregion
@@ -106,7 +107,7 @@ public class Piece
         PieceClassifier pc;
         var capitalizedPieceClassifier = state.PieceClassifier.ToUpper();
         if(Enum.TryParse(capitalizedPieceClassifier, out pc))
-            return new Piece(movement, captures, state.Royal, pc, state.Repeat, state.PieceIdentifier, state.CanBeCaptured);
+            return new Piece(movement, captures, pc, state.Repeat, state.PieceIdentifier, state.CanBeCaptured, state.CanBePromotedTo);
 
         throw new ArgumentException("PieceClassifier could not be parsed correctly.");
     }
@@ -142,8 +143,8 @@ public class Piece
         var mp = new MovementPattern(patterns);
 
         if(pieceClassifier.Equals(PieceClassifier.WHITE))
-            return new Piece(mp, mp,  false, pieceClassifier, Constants.WhiteRookIdentifier);
-        return new Piece(mp, mp, false, pieceClassifier, Constants.BlackRookIdentifier);
+            return new Piece(mp, mp, pieceClassifier, Constants.WhiteRookIdentifier);
+        return new Piece(mp, mp, pieceClassifier, Constants.BlackRookIdentifier);
     }
 
     /// <summary>
@@ -162,8 +163,8 @@ public class Piece
         var mp = new MovementPattern(patterns);
 
         if(pieceClassifier.Equals(PieceClassifier.WHITE))
-            return new Piece(mp, mp, false, pieceClassifier, Constants.WhiteBishopIdentifier);
-        return new Piece(mp, mp, false, pieceClassifier, Constants.BlackBishopIdentifier);
+            return new Piece(mp, mp, pieceClassifier, Constants.WhiteBishopIdentifier);
+        return new Piece(mp, mp, pieceClassifier, Constants.BlackBishopIdentifier);
     }
 
     /// <summary>
@@ -186,8 +187,8 @@ public class Piece
         var mp = new MovementPattern(patterns);
 
         if(pieceClassifier.Equals(PieceClassifier.WHITE))
-            return new Piece(mp, mp, false, pieceClassifier, Constants.WhiteQueenIdentifier);
-        return new Piece(mp, mp, false, pieceClassifier, Constants.BlackQueenIdentifier);
+            return new Piece(mp, mp, pieceClassifier, Constants.WhiteQueenIdentifier);
+        return new Piece(mp, mp, pieceClassifier, Constants.BlackQueenIdentifier);
     }
 
     /// <summary>
@@ -209,8 +210,8 @@ public class Piece
         };
         var mp = new MovementPattern(patterns);
         if(pieceClassifier.Equals(PieceClassifier.WHITE))
-            return new Piece(mp, mp, true, pieceClassifier, Constants.WhiteKingIdentifier);
-        return new Piece(mp, mp, true, pieceClassifier, Constants.BlackKingIdentifier);
+            return new Piece(mp, mp, pieceClassifier, Constants.WhiteKingIdentifier, canBePromotedTo: false);
+        return new Piece(mp, mp, pieceClassifier, Constants.BlackKingIdentifier, canBePromotedTo: false);
     }
 
     /// <summary>
@@ -232,8 +233,8 @@ public class Piece
         };
         var mp = new MovementPattern(pattern);
         if(pieceClassifier.Equals(PieceClassifier.WHITE))
-            return new Piece(mp, mp, false, pieceClassifier,Constants.WhiteKnightIdentifier);
-        return new Piece(mp, mp, false, pieceClassifier,Constants.BlackKnightIdentifier);
+            return new Piece(mp, mp, pieceClassifier,Constants.WhiteKnightIdentifier);
+        return new Piece(mp, mp, pieceClassifier,Constants.BlackKnightIdentifier);
     }
 
     /// <summary>
@@ -251,7 +252,7 @@ public class Piece
         };
         var mp = new MovementPattern(patterns);
         var cp = new MovementPattern(capturePatterns);
-        return new Piece(mp, cp, false, PieceClassifier.BLACK, Constants.BlackPawnIdentifier);
+        return new Piece(mp, cp, PieceClassifier.BLACK, Constants.BlackPawnIdentifier, canBePromotedTo: false);
     }
 
     /// <summary>
@@ -269,7 +270,7 @@ public class Piece
         };
         var mp = new MovementPattern(patterns);
         var cp = new MovementPattern(capturePatterns);
-        return new Piece(mp, cp, false, PieceClassifier.WHITE, Constants.WhitePawnIdentifier);
+        return new Piece(mp, cp, PieceClassifier.WHITE, Constants.WhitePawnIdentifier, canBePromotedTo: false);
     }
 
     /// <summary>
@@ -292,7 +293,7 @@ public class Piece
 
         var mp = new MovementPattern(patterns);
         var cp = new MovementPattern(capturePatterns);
-        return new Piece(mp, cp, false, PieceClassifier.SHARED, Constants.DuckIdentifier, false);
+        return new Piece(mp, cp, PieceClassifier.SHARED, Constants.DuckIdentifier, false, canBePromotedTo: false);
     }
 
     /// <summary>

--- a/ChessVariantsLogic/Piece/PieceBuilder.cs
+++ b/ChessVariantsLogic/Piece/PieceBuilder.cs
@@ -17,6 +17,7 @@ public class PieceBuilder
     private PieceClassifier pc;
     private int repeat;
     private bool canBeCaptured;
+    private bool canBePromotedTo;
 
     private bool sameCaptureAsMovement;
 
@@ -78,9 +79,9 @@ public class PieceBuilder
             pieceString = this.pc == PieceClassifier.WHITE ? whiteCustomPieceIdentifier : blackCustomPieceIdentifier; 
 
         if(sameCaptureAsMovement)
-            return new Piece(this.movementPattern, this.movementPattern, this.royal, this.pc, this.repeat, pieceString, this.canBeCaptured);
+            return new Piece(this.movementPattern, this.movementPattern, this.pc, this.repeat, pieceString, this.canBeCaptured, this.canBePromotedTo);
         else
-            return new Piece(this.movementPattern, this.capturePattern, this.royal, this.pc, this.repeat, pieceString, this.canBeCaptured);
+            return new Piece(this.movementPattern, this.capturePattern, this.pc, this.repeat, pieceString, this.canBeCaptured, this.canBePromotedTo);
     }
 
     /// <summary>
@@ -94,7 +95,7 @@ public class PieceBuilder
         //Create helper class to remove dependency on MoveWorker and to avoid creating new objects each time this method is called?
 
         var moveWorker = new MoveWorker(new Chessboard(8));
-        var dummyPiece = new Piece(this.movementPattern, this.movementPattern, false, PieceClassifier.WHITE, this.repeat, whiteCustomPieceIdentifier, this.canBeCaptured);
+        var dummyPiece = new Piece(this.movementPattern, this.movementPattern, PieceClassifier.WHITE, this.repeat, whiteCustomPieceIdentifier, this.canBeCaptured, this.canBePromotedTo);
         if(moveWorker.InsertOnBoard(dummyPiece, square))
             return moveWorker.GetAllValidMoves(Player.White);
         throw new ArgumentException("Invalid square for an 8x8 chessboard.");
@@ -102,12 +103,12 @@ public class PieceBuilder
 
     public Piece GetDummyPieceWithCurrentMovement()
     {
-        return new Piece(this.movementPattern, this.movementPattern, false, PieceClassifier.WHITE, this.repeat, whiteCustomPieceIdentifier, this.canBeCaptured);
+        return new Piece(this.movementPattern, this.movementPattern, PieceClassifier.WHITE, this.repeat, whiteCustomPieceIdentifier, this.canBeCaptured, this.canBePromotedTo);
     }
 
     public Piece GetDummyPieceWithCurrentCaptures()
     {
-        return new Piece(this.capturePattern, this.capturePattern, false, PieceClassifier.WHITE, this.repeat, whiteCustomPieceIdentifier, this.canBeCaptured);
+        return new Piece(this.capturePattern, this.capturePattern, PieceClassifier.WHITE, this.repeat, whiteCustomPieceIdentifier, this.canBeCaptured, this.canBePromotedTo);
     }
 
     /// <summary>
@@ -124,7 +125,7 @@ public class PieceBuilder
             return GetAllCurrentlyValidMovesFromSquare(square);
             
         var moveWorker = new MoveWorker(new Chessboard(8));
-        var dummyPiece = new Piece(this.capturePattern, this.capturePattern, false, PieceClassifier.WHITE, this.repeat, whiteCustomPieceIdentifier, this.canBeCaptured);
+        var dummyPiece = new Piece(this.capturePattern, this.capturePattern, PieceClassifier.WHITE, this.repeat, whiteCustomPieceIdentifier, this.canBeCaptured, this.canBePromotedTo);
         if(moveWorker.InsertOnBoard(dummyPiece, square))
             return moveWorker.GetAllValidMoves(Player.White);
         throw new ArgumentException("Invalid square for an 8x8 chessboard.");

--- a/ChessVariantsLogic/PieceExporter.cs
+++ b/ChessVariantsLogic/PieceExporter.cs
@@ -28,8 +28,8 @@ public static class PieceExporter
         {
             Movement = exportPattern(piece.GetAllMovementPatterns()),
             Captures = exportPattern(piece.GetAllCapturePatterns()),
-            Royal = piece.Royal,
             CanBeCaptured = piece.CanBeCaptured,
+            CanBePromotedTo = piece.CanBePromotedTo,
             PieceClassifier = piece.PieceClassifier.AsString(),
             PieceIdentifier = piece.PieceIdentifier,
             Repeat = piece.Repeat,
@@ -81,6 +81,9 @@ public record PieceState
 
     [JsonProperty("canBeCaptured")]
     public bool CanBeCaptured { get; set; }
+
+    [JsonProperty("canBePromotedTo")]
+    public bool CanBePromotedTo { get; set; }
 
     public string AsJson()
     {

--- a/DataAccess.MongoDB/Database/DatabaseService.cs
+++ b/DataAccess.MongoDB/Database/DatabaseService.cs
@@ -1,4 +1,5 @@
-﻿using MongoDB.Driver;
+﻿using MongoDB.Bson;
+using MongoDB.Driver;
 
 namespace DataAccess.MongoDB;
 
@@ -11,11 +12,18 @@ public abstract class DatabaseService
     private readonly IMongoClient _client;
     private readonly IMongoDatabase _database;
     public readonly UserRepository Users;
+    public readonly PieceRepository Pieces;
 
     public DatabaseService(string connectionString, string databaseName)
     {
         _client = new MongoClient(connectionString);
         _database = _client.GetDatabase(databaseName);
         Users = new UserRepository(_database);
+        Pieces = new PieceRepository(_database);
     }
+
+    //public string ObjecatId()
+    //{
+    //    return ObjectId();
+    //}
 }

--- a/DataAccess.MongoDB/Models/Piece.cs
+++ b/DataAccess.MongoDB/Models/Piece.cs
@@ -25,6 +25,9 @@ public record Piece : IModel
     [BsonElement("canBeCaptured")]
     public bool CanBeCaptured { get; set; } = true;
 
+    [BsonElement("canBePromotedTo")]
+    public bool CanBePromotedTo { get; set; } = true;
+
     [BsonElement("imagePath")]
     public string ImagePath { get; set; } = null!;
 

--- a/DataAccess.MongoDB/Models/Piece.cs
+++ b/DataAccess.MongoDB/Models/Piece.cs
@@ -1,0 +1,51 @@
+﻿using MongoDB.Bson;
+using MongoDB.Bson.Serialization.Attributes;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace DataAccess.MongoDB.Models;
+public record Piece : IModel
+{
+    [BsonId]
+    [BsonRepresentation(BsonType.ObjectId)]
+    public string Id { get; set; } = null!;
+
+    [BsonElement("name")]
+    public string Name { get; set; } = null!;
+
+    [BsonElement("creator")]
+    public string Creator { get; set; } = null!;
+
+    [BsonElement("repeat")]
+    public int Repeat { get; set; } = 0;
+
+    [BsonElement("canBeCaptured")]
+    public bool CanBeCaptured { get; set; } = true;
+
+    [BsonElement("imagePath")]
+    public string ImagePath { get; set; } = null!;
+
+    [BsonElement("movement")]
+    public List<MovePattern> Movement { get; set; } = new List<MovePattern>();
+
+    [BsonElement("captures")]
+    public List<MovePattern> Captures { get; set; } = new List<MovePattern>();
+}
+
+public record MovePattern
+{
+    [BsonElement("xDir")]
+    public int XDir { get; set; } = 0;
+
+    [BsonElement("yDir")]
+    public int YDir { get; set; } = 0;
+
+    [BsonElement("minLength")]
+    public int MinLength { get; set; } = 0;
+
+    [BsonElement("maxLength")]
+    public int MaxLength { get; set; } = 0;
+}

--- a/DataAccess.MongoDB/Repositories/PieceRepository.cs
+++ b/DataAccess.MongoDB/Repositories/PieceRepository.cs
@@ -1,0 +1,10 @@
+﻿using DataAccess.MongoDB.Models;
+using MongoDB.Driver;
+
+namespace DataAccess.MongoDB;
+public class PieceRepository : GenericRepository<Piece>
+{
+    public const string CollectionName = "Pieces";
+
+    public PieceRepository(IMongoDatabase database) : base(database.GetCollection<Piece>(CollectionName)) {}
+}


### PR DESCRIPTION
This PR contains logic for saving a piece to the database.

A model for a saved piece has been created and a `PieceTranslator` class for translating a `ChessLogic.Piece` to a `DataAccess.Piece`. The test and PieceController show example use cases. The controller will probably not be used unless changed, but I left it in to show how we to use the functionality. It can be removed at a later point.