### PR TITLE
Full promotion functionality

### DIFF
--- a/ChessVariantsAPI/GameOrganization/ActiveGame.cs
+++ b/ChessVariantsAPI/GameOrganization/ActiveGame.cs
@@ -157,7 +157,12 @@ public class ActiveGame
 
         foreach (var key in _playerDict.Keys)
         {
-            _playerDict[key] = _playerDict[key] == Player.White ? Player.Black : Player.White;
+            var newColor = _playerDict[key] == Player.White ? Player.Black : Player.White;
+            if (_game != null && _game.ActiveAI && _playerDict[key] == _game.GetAIColor())
+            {
+                _game.AssignAINewColor(newColor);
+            }
+            _playerDict[key] = newColor;
         }
     }
 

--- a/ChessVariantsAPI/Hubs/DTOs/PromotionOptionsDTO.cs
+++ b/ChessVariantsAPI/Hubs/DTOs/PromotionOptionsDTO.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using Newtonsoft.Json;
+
+namespace ChessVariantsAPI.Hubs.DTOs;
+
+public record PromotionOptionsDTO
+{
+    [JsonProperty("promotablePieces")]
+    public List<string> PromotablePieces { get; set; } = null!;
+
+    [JsonProperty("player")]
+    public string Player { get; set; } = null!;
+}
+
+public record PieceInfo
+{
+    [JsonProperty("identifier")]
+    public string Identifier { get; set; } = null!;
+
+    [JsonProperty("imagePath")]
+    public string ImagePath { get; set; } = null!;
+}

--- a/ChessVariantsAPI/Hubs/IClientProxyExtensions.cs
+++ b/ChessVariantsAPI/Hubs/IClientProxyExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using ChessVariantsAPI.GameOrganization;
+using ChessVariantsAPI.Hubs.DTOs;
 using ChessVariantsLogic.Export;
 using Microsoft.AspNetCore.SignalR;
 
@@ -86,6 +87,16 @@ public static class IClientProxyExtensions
         await clients.SendAsync(Events.InvalidMove);
     }
 
+    public static async Task SendPromotionOptions(this IClientProxy clients, PromotionOptionsDTO promotionOptionsDTO)
+    {
+        await clients.SendAsync(Events.Promotion, promotionOptionsDTO);
+    }
+
+    public static async Task SendPromotionDone(this IClientProxy clients)
+    {
+        await clients.SendAsync(Events.Promoted);
+    }
+
     public static async Task SendUpdatedEditorState(this IClientProxy clients, EditorState state)
     {
         await clients.SendAsync(Events.UpdatedEditorState, state);
@@ -114,6 +125,9 @@ public static class Events
     public readonly static string BlackWon = "blackWon";
     public readonly static string Tie = "tie";
     public readonly static string Colors = "colors";
+    public readonly static string Promotion = "promotion";
+    public readonly static string Promoted = "promoted";
+
 
     // Lobby events
     public readonly static string PlayerJoinedLobby = "playerJoinedLobby";

--- a/ChessVariantsLogic.Tests/GameTests.cs
+++ b/ChessVariantsLogic.Tests/GameTests.cs
@@ -1,0 +1,41 @@
+﻿using System;
+namespace ChessVariantsLogic.Tests;
+
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+
+public class GameTests
+{
+    Game game;
+
+    public GameTests()
+    {
+        game = GameFactory.StandardChess();
+    }
+
+    [Fact]
+    public void GetPromotablePieces_ShouldOnlyReturnPiecesForWhite()
+    {
+        var promotablePieces = game.GetPromotablePieces();
+        Assert.All(
+            promotablePieces,
+            piece => Assert.True(piece.PieceClassifier == PieceClassifier.WHITE)
+            );
+    }
+
+    [Fact]
+    public void GetPromotablePieces_ShouldContainAllButKingAndPawn()
+    {
+        var promotablePieces = game.GetPromotablePieces();
+        Assert.Equal(1, promotablePieces.Count(p => p.PieceIdentifier == Constants.WhiteBishopIdentifier));
+        Assert.Equal(1, promotablePieces.Count(p => p.PieceIdentifier == Constants.WhiteKnightIdentifier));
+        Assert.Equal(1, promotablePieces.Count(p => p.PieceIdentifier == Constants.WhiteQueenIdentifier));
+        Assert.Equal(1, promotablePieces.Count(p => p.PieceIdentifier == Constants.WhiteRookIdentifier));
+        Assert.Equal(0, promotablePieces.Count(p => p.PieceIdentifier == Constants.WhiteKingIdentifier));
+        Assert.Equal(0, promotablePieces.Count(p => p.PieceIdentifier == Constants.WhitePawnIdentifier));
+        Assert.Equal(4, promotablePieces.Count());
+    }
+}
+

--- a/ChessVariantsLogic/Engine/AIPlayer.cs
+++ b/ChessVariantsLogic/Engine/AIPlayer.cs
@@ -4,7 +4,7 @@ namespace ChessVariantsLogic.Engine;
 public class AIPlayer
 {
     private readonly IMoveFinder _moveFinder;
-    public readonly Player PlayingAs;
+    public Player PlayingAs { get; set; }
 
     public AIPlayer(IMoveFinder moveFinder, Player player)
     {
@@ -15,5 +15,10 @@ public class AIPlayer
     public Move SearchMove(Game game, int depth=3)
     {
         return _moveFinder.FindBestMove(depth, game, PlayingAs, ScoreVariant.RegularChess);
+    }
+
+    public string GetMostValuablePieceIdentifier(ISet<string> promotablePieces, Player forPlayer)
+    {
+        return _moveFinder.GetPieceValue().GetHighestValuePieceIdentifier(promotablePieces, forPlayer);
     }
 }

--- a/ChessVariantsLogic/Engine/IMoveFinder.cs
+++ b/ChessVariantsLogic/Engine/IMoveFinder.cs
@@ -3,5 +3,7 @@
 namespace ChessVariantsLogic.Engine;
 public interface IMoveFinder
 {
+
     public Move FindBestMove(int depth, Game game, Player player, ScoreVariant scoreVariant);
+    public PieceValue GetPieceValue();
 }

--- a/ChessVariantsLogic/Engine/NegaMax.cs
+++ b/ChessVariantsLogic/Engine/NegaMax.cs
@@ -28,6 +28,11 @@ public class NegaMax : IMoveFinder
     private HeatMap _heatMap;
 
 
+    public PieceValue GetPieceValue()
+    {
+        return _pieceValue;
+    }
+
 
     /// <summary>
     /// Calculates the best move for a player using negaMax algorithm

--- a/ChessVariantsLogic/Engine/PieceValue.cs
+++ b/ChessVariantsLogic/Engine/PieceValue.cs
@@ -59,6 +59,17 @@ public class PieceValue
         return _pieceValue[piece];
     }
 
+    public string GetHighestValuePieceIdentifier(ISet<string> promotablePieces, Player forPlayer)
+    {
+        var promotableEntires = _pieceValue.Where(pv => promotablePieces.Contains(pv.Key));
+        if (forPlayer == Player.White)
+        {
+            return promotableEntires.OrderByDescending(pv => pv.Value).First().Key;
+        }
+        return 
+        promotableEntires.OrderBy(pv => pv.Value).First().Key;
+    }
+
     private double calculateMovementValue(Piece piece)
     {
         double value = 0;

--- a/ChessVariantsLogic/Game.cs
+++ b/ChessVariantsLogic/Game.cs
@@ -257,12 +257,30 @@ public class Game {
 
     public string ExportStateAsJson()
     {
-        return GameExporter.ExportGameStateAsJson(_moveWorker.Board, PlayerTurn, GetLegalMoveDict());
+        return ExportState().AsJson();
     }
 
     public GameState ExportState()
     {
-        return GameExporter.ExportGameState(_moveWorker.Board, PlayerTurn, GetLegalMoveDict());
+        try
+        {
+            string latestMoveFrom = _moveWorker.Movelog.Last().From;
+            string latestMoveTo = _moveWorker.Movelog.Last().To;
+            var indexFromTopFrom = CalculateIndexFromTopOfBoardToSquare(latestMoveFrom);
+            var indexFromTopTo = CalculateIndexFromTopOfBoardToSquare(latestMoveTo);
+            return GameExporter.ExportGameState(_moveWorker.Board, PlayerTurn, GetLegalMoveDict(), indexFromTopFrom, indexFromTopTo);
+        }
+        catch (InvalidOperationException)
+        {
+            return GameExporter.ExportGameState(_moveWorker.Board, PlayerTurn, GetLegalMoveDict());
+        }
+    }
+
+    private int CalculateIndexFromTopOfBoardToSquare(string square)
+    {
+        var rowColIndices = _moveWorker.Board.CoorToIndex[square];
+        var indexFromTop = _moveWorker.Board.Rows * rowColIndices.Item1 + rowColIndices.Item2;
+        return indexFromTop;
     }
 }
 

--- a/ChessVariantsLogic/GameExporter.cs
+++ b/ChessVariantsLogic/GameExporter.cs
@@ -23,14 +23,21 @@ public static class GameExporter
     /// <param name="sideToMove">The side whose turn it is to move</param>
     /// <param name="moveDict">Moves to export</param>
     /// <returns></returns>
-    public static GameState ExportGameState(Chessboard chessboard, Player sideToMove, Dictionary<string, List<string>> moveDict)
+    public static GameState ExportGameState(
+        Chessboard chessboard,
+        Player sideToMove,
+        Dictionary<string, List<string>> moveDict,
+        int? lastestMoveFromIndex = null,
+        int? lastestMoveToIndex = null)
     {
         return new GameState
         {
             SideToMove = sideToMove.AsString(),
             Board = ExportBoard(chessboard),
             BoardSize = new BoardSize { Rows = chessboard.Rows, Cols = chessboard.Cols },
-            Moves = ExportMoves(moveDict)
+            Moves = ExportMoves(moveDict),
+            LatestMoveFromIndex = lastestMoveFromIndex,
+            LatestMoveToIndex = lastestMoveToIndex,
         };
     }
 
@@ -108,6 +115,12 @@ public record GameState
 
     [JsonProperty("moves")]
     public List<MoveRecord> Moves { get; set; } = null!;
+
+    [JsonProperty("latestMoveFromIndex")]
+    public int? LatestMoveFromIndex { get; set; } = null!;
+
+    [JsonProperty("latestMoveToIndex")]
+    public int? LatestMoveToIndex { get; set; } = null!;
 
     public string AsJson()
     {

--- a/ChessVariantsLogic/Movement/MoveWorker.cs
+++ b/ChessVariantsLogic/Movement/MoveWorker.cs
@@ -72,6 +72,11 @@ public class MoveWorker
         string from = splitMove.Item1;
         string to = splitMove.Item2;
 
+        if (from == to && force)
+        {
+            return GameEvent.MoveSucceeded;
+        }
+
         string? strPiece = board.GetPieceIdentifier(from);
         if (strPiece == null) return GameEvent.InvalidMove;
         
@@ -110,6 +115,11 @@ public class MoveWorker
         if(piece == null)
             throw new ArgumentException("Invalid PieceIdentifier: " + identifier);
         return piece;
+    }
+
+    public ISet<Piece> GetPieces()
+    {
+        return pieces;
     }
 
     /// <summary>

--- a/ChessVariantsLogic/Rules/Event.cs
+++ b/ChessVariantsLogic/Rules/Event.cs
@@ -40,8 +40,7 @@ public class Event
         IPredicate pawnMoved = new PieceMoved(pawnIdentifier);
         IPredicate pawnAtRank = new SquareHasRank(new PositionRelative(0, 0, RelativeTo.TO), rank);
 
-        List<Action> actions = new List<Action> { new ActionSetPiece(new PositionRelative(0, 0, RelativeTo.TO), queenIdentifier) };
-
+        var actions = new List<Action> { new ActionPromotionTime() };
         return new Event(pawnMoved & pawnAtRank, actions);
     }
 

--- a/ChessVariantsLogic/Rules/Moves/Actions/ActionPromotionTime.cs
+++ b/ChessVariantsLogic/Rules/Moves/Actions/ActionPromotionTime.cs
@@ -1,0 +1,15 @@
+﻿using System;
+namespace ChessVariantsLogic.Rules.Moves.Actions;
+
+public class ActionPromotionTime : Action
+{
+    public ActionPromotionTime()
+    {
+    }
+
+    public override GameEvent Perform(MoveWorker moveWorker, string moveCoordinates)
+    {
+        return GameEvent.Promotion;
+    }
+}
+

--- a/ChessVariantsLogic/Rules/RuleSet.cs
+++ b/ChessVariantsLogic/Rules/RuleSet.cs
@@ -121,7 +121,7 @@ public class RuleSet
             }
         }
 
-        gameEvents.IntersectWith(new HashSet<GameEvent>() { GameEvent.Tie, GameEvent.WhiteWon, GameEvent.BlackWon });
+        gameEvents.IntersectWith(new HashSet<GameEvent>() { GameEvent.Tie, GameEvent.WhiteWon, GameEvent.BlackWon, GameEvent.Promotion });
         if (gameEvents.Count > 1)
             throw new Exception("Running events return multiple win/tie events. Events: " + gameEvents);
 


### PR DESCRIPTION
This PR adds the possibility for selecting what piece to promote to. It also allows the AI to promote pieces. Some cleanup was done by removing the `royal` field from `Piece`. However, `Piece` now has a new field called `canBePromotedTo` which signifies if promotion to that piece should be possible. In standard chess this means that all pieces except the king and pawn will have that field as `true`.

Also adds the most recent move made to `GameState` so that the frontend can highlight these moves.