### PR TITLE
Fix board square sequential index calculation

### DIFF
--- a/ChessVariantsLogic/Game.cs
+++ b/ChessVariantsLogic/Game.cs
@@ -279,7 +279,7 @@ public class Game {
     private int CalculateIndexFromTopOfBoardToSquare(string square)
     {
         var rowColIndices = _moveWorker.Board.CoorToIndex[square];
-        var indexFromTop = _moveWorker.Board.Rows * rowColIndices.Item1 + rowColIndices.Item2;
+        var indexFromTop = _moveWorker.Board.Cols * rowColIndices.Item1 + rowColIndices.Item2;
         return indexFromTop;
     }
 }


### PR DESCRIPTION
Fixes bug in calculating the sequential index of the board, used for move highlighting in FE.